### PR TITLE
🎉 .editorconfigを追加

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,18 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = space
+indent_size = 2
+
+[*.{yaml,yml}]
+indent_size = 2
+
+[*.md]
+trim_trailing_whitespace = false
+
+[*.nix]
+indent_size = 2


### PR DESCRIPTION
# チケット

close #18

# 概要

プロジェクトに`.editorconfig`が存在せず、異なるエディタ/IDE間で一貫したコーディングスタイルを保証する仕組みがなかった。Biomeによるフォーマットはpre-commitフックで実行されるが、編集中のインデントや改行コードの不一致は開発体験を損なうため、エディタレベルで一貫したスタイルを適用する。

### 追加内容

- インデント: 2スペース（Biome設定と整合）
- 文字エンコーディング: UTF-8
- 改行コード: LF
- ファイル末尾に改行を挿入
- 末尾の空白を削除（Markdownは例外: 改行扱いのため保持）

# その他

resolves #18