### PR TITLE
ロガーをファクトリパターンにリファクタリングし設定駆動のログレベル管理を実装

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,17 +57,81 @@ nix develop --command lefthook run pre-commit
 
 ### 主要スクリプト
 
-| スクリプト   | 用途                       | 実行例                             |
-| ------------ | -------------------------- | ---------------------------------- |
-| `pnpm check` | Biomeチェック + 型検査     | `nix develop --command pnpm check` |
-| `pnpm build` | esbuildバンドル            | `nix develop --command pnpm build` |
-| `pnpm fmt`   | Biomeフォーマット          | `nix develop --command pnpm fmt`   |
-| `pnpm lint`  | Biomeリント                | `nix develop --command pnpm lint`  |
-| `pnpm dev`   | 開発サーバー起動           | `nix develop --command pnpm dev`   |
+| スクリプト   | 用途                   | 実行例                             |
+| ------------ | ---------------------- | ---------------------------------- |
+| `pnpm check` | Biomeチェック + 型検査 | `nix develop --command pnpm check` |
+| `pnpm build` | esbuildバンドル        | `nix develop --command pnpm build` |
+| `pnpm fmt`   | Biomeフォーマット      | `nix develop --command pnpm fmt`   |
+| `pnpm lint`  | Biomeリント            | `nix develop --command pnpm lint`  |
+| `pnpm dev`   | 開発サーバー起動       | `nix develop --command pnpm dev`   |
 
 ### 設定
 
 アプリ設定は `src/app/config/config.yaml` にYAML形式で定義し、`BotConfig`インターフェースで型付けする。
+
+### ロギング
+
+ロガーは `src/shared/utils/logger.ts` でPinoベースのファクトリパターンで実装する。
+
+#### ロガーの利用
+
+- `getLogger()` でロガーインスタンスを取得する。直接 `pino` をインポートしない。
+- `import { getLogger } from "@/shared/utils/logger"` でインポートする。
+- ロガーの初期化は `bootstrap()` 内で `createLogger(config.logging)` を呼び出して行う。
+- ミドルウェア等の各モジュールでは `getLogger()` を呼び出してロガーを使用する。
+
+#### ログレベル
+
+- `config.yaml` の `logging.level` で上書き可能。
+- 未指定時は `NODE_ENV` に基づくデフォルト値を使用:
+  - `production`: `info`
+  - `development`: `debug`
+  - `test`: `silent`
+- 有効なレベル: `fatal`, `error`, `warn`, `info`, `debug`, `trace`, `silent`
+
+#### ログレベルの使い分け
+
+| レベル  | 用途                                       | 例                                                |
+| ------- | ------------------------------------------ | ------------------------------------------------- |
+| `fatal` | アプリケーションが継続不可能な致命的障害   | Discordトークン不正で起動失敗、必須設定の欠落     |
+| `error` | 処理の失敗。即座の対応は不要だが調査が必要 | API呼び出しの失敗、DB接続エラー、予期しない例外   |
+| `warn`  | 想定外だが処理は継続可能な問題             | 非推奨APIの使用、リトライ成功、フォールバック動作 |
+| `info`  | 正常な業務処理の記録                       | サーバー起動、リクエストの開始/終了、コマンド実行 |
+| `debug` | 開発・デバッグ用の詳細情報                 | 関数の引数・戻り値、分岐条件の結果、内部状態      |
+
+#### 構造化ログ
+
+- コンテキスト情報は第一引数にオブジェクトで渡し、第二引数にメッセージを渡す:
+  ```typescript
+  getLogger().info({ requestId, method, path }, "request start");
+  ```
+- 文字列補間は使わず、関連情報はすべてオブジェクトに含める:
+  ```typescript
+  // 良い例
+  getLogger().info({ port: 3000 }, "Server started");
+  // 悪い例
+  getLogger().info(`Server started on port ${port}`);
+  ```
+
+#### 機密情報の取り扱い
+
+- 以下をログ出力に含めてはならない:
+  - Discord Botトークン
+  - APIキー（OpenAI等）
+  - ユーザーの個人情報（ID、メールアドレス等）
+  - セッション情報・認証トークン
+- 外部APIへのリクエスト/レスポンスをログに出力する場合、ヘッダーの認証情報は除外する。
+
+#### ログフォーマット
+
+- `NODE_ENV` に基づいて自動的に切り替わる（`config.yaml` での指定は不可）:
+  - `production`: JSON形式
+  - `development` / `test`: pino-pretty（カラー付き）
+
+#### テスト
+
+- テストでは `vi.mock("@/shared/utils/logger", () => ({ getLogger: vi.fn().mockReturnValue({ info: vi.fn() }) }))` でモック化する。
+- テスト内でロガーの振る舞いを検証する場合は `resetLogger()` でキャッシュをクリアする。
 
 ### テスト
 

--- a/src/app/bootstrap.test.ts
+++ b/src/app/bootstrap.test.ts
@@ -1,25 +1,38 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+const mockCreateLogger = vi.fn();
+const mockInfo = vi.fn();
+const mockDebug = vi.fn();
+
 vi.mock("@/shared/utils/logger", () => ({
-  logger: { info: vi.fn() },
+  createLogger: (...args: unknown[]) => mockCreateLogger(...args),
+  getLogger: vi.fn().mockReturnValue({
+    info: (...args: unknown[]) => mockInfo(...args),
+    debug: (...args: unknown[]) => mockDebug(...args),
+  }),
 }));
 
-describe("bootstrap", () => {
+function setupMocks(config: Record<string, unknown>) {
+  vi.doMock("@/app/config/bot.config", () => ({
+    loadConfig: vi.fn().mockReturnValue(config),
+  }));
+  vi.doMock("@/server/hono", () => ({
+    createApp: vi.fn().mockReturnValue({ fetch: vi.fn() }),
+  }));
+}
+
+describe("bootstrap result", () => {
   beforeEach(() => {
     vi.resetModules();
     vi.restoreAllMocks();
   });
 
   it("returns app with fetch method and port from config", async () => {
-    vi.doMock("@/app/config/bot.config", () => ({
-      loadConfig: vi.fn().mockReturnValue({
-        bot: { defaultModel: "codex-mini", maxTokens: 4096, timeoutMs: 30000 },
-        server: { port: 3000 },
-      }),
-    }));
-    vi.doMock("@/server/hono", () => ({
-      createApp: vi.fn().mockReturnValue({ fetch: vi.fn() }),
-    }));
+    setupMocks({
+      bot: { defaultModel: "codex-mini", maxTokens: 4096, timeoutMs: 30000 },
+      server: { port: 3000 },
+      logging: { level: "info" },
+    });
 
     const { bootstrap } = await import("@/app/bootstrap");
 
@@ -27,6 +40,57 @@ describe("bootstrap", () => {
 
     expect(typeof result.app.fetch).toBe("function");
     expect(result.port).toBe(3000);
+  });
+});
+
+describe("bootstrap logging", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.restoreAllMocks();
+    mockCreateLogger.mockReset();
+    mockInfo.mockReset();
+    mockDebug.mockReset();
+  });
+
+  it("calls createLogger with logging config", async () => {
+    const loggingConfig = { level: "debug" };
+    setupMocks({
+      bot: { defaultModel: "codex-mini", maxTokens: 4096, timeoutMs: 30000 },
+      server: { port: 3000 },
+      logging: loggingConfig,
+    });
+
+    const { bootstrap } = await import("@/app/bootstrap");
+
+    bootstrap();
+
+    expect(mockCreateLogger).toHaveBeenCalledWith(loggingConfig);
+  });
+
+  it("logs config and bootstrap completion", async () => {
+    const config = {
+      bot: { defaultModel: "codex-mini", maxTokens: 4096, timeoutMs: 30000 },
+      server: { port: 3000 },
+      logging: { level: "info" },
+    };
+    setupMocks(config);
+
+    const { bootstrap } = await import("@/app/bootstrap");
+
+    bootstrap();
+
+    expect(mockDebug).toHaveBeenCalledWith({ config }, "Config loaded");
+    expect(mockInfo).toHaveBeenCalledWith(
+      { port: config.server.port },
+      "Bootstrap completed",
+    );
+  });
+});
+
+describe("bootstrap error", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.restoreAllMocks();
   });
 
   it("propagates loadConfig error", async () => {

--- a/src/app/bootstrap.ts
+++ b/src/app/bootstrap.ts
@@ -1,8 +1,15 @@
 import { loadConfig } from "@/app/config/bot.config";
 import { createApp } from "@/server/hono";
+import { createLogger, getLogger } from "@/shared/utils/logger";
 
 export function bootstrap() {
   const config = loadConfig();
+
+  createLogger(config.logging);
+
+  const log = getLogger();
+  log.debug({ config }, "Config loaded");
+  log.info({ port: config.server.port }, "Bootstrap completed");
 
   const app = createApp();
 

--- a/src/app/config/bot.config.test.ts
+++ b/src/app/config/bot.config.test.ts
@@ -129,6 +129,79 @@ describe("botConfigSchema invalid server fields", () => {
   });
 });
 
+describe("botConfigSchema logging valid", () => {
+  it("accepts config without logging section", () => {
+    const result = botConfigSchema.parse({
+      bot: { defaultModel: "codex-mini", maxTokens: 4096, timeoutMs: 30000 },
+      server: { port: 3000 },
+    });
+
+    expect(result).not.toHaveProperty("logging");
+  });
+
+  it.each([
+    "fatal",
+    "error",
+    "warn",
+    "info",
+    "debug",
+    "trace",
+    "silent",
+  ])("accepts logging with valid level %s", (level) => {
+    const result = botConfigSchema.parse({
+      bot: {
+        defaultModel: "codex-mini",
+        maxTokens: 4096,
+        timeoutMs: 30000,
+      },
+      server: { port: 3000 },
+      logging: { level },
+    });
+
+    expect(result.logging?.level).toBe(level);
+  });
+
+  it("accepts logging without level", () => {
+    const result = botConfigSchema.parse({
+      bot: { defaultModel: "codex-mini", maxTokens: 4096, timeoutMs: 30000 },
+      server: { port: 3000 },
+      logging: {},
+    });
+
+    expect(result.logging).toEqual({});
+  });
+});
+
+describe("botConfigSchema logging invalid", () => {
+  it("rejects invalid log level string", () => {
+    expect(() =>
+      botConfigSchema.parse({
+        bot: {
+          defaultModel: "codex-mini",
+          maxTokens: 4096,
+          timeoutMs: 30000,
+        },
+        server: { port: 3000 },
+        logging: { level: "verbose" },
+      }),
+    ).toThrow();
+  });
+
+  it("rejects non-string log level", () => {
+    expect(() =>
+      botConfigSchema.parse({
+        bot: {
+          defaultModel: "codex-mini",
+          maxTokens: 4096,
+          timeoutMs: 30000,
+        },
+        server: { port: 3000 },
+        logging: { level: 123 },
+      }),
+    ).toThrow();
+  });
+});
+
 async function setupLoadConfig(mockValue: string) {
   const { readFileSync } = await import("node:fs");
   vi.mocked(readFileSync).mockReturnValue(mockValue);

--- a/src/app/config/bot.config.ts
+++ b/src/app/config/bot.config.ts
@@ -2,6 +2,16 @@ import { readFileSync } from "node:fs";
 import YAML from "yaml";
 import { z } from "zod";
 
+export const logLevelSchema = z.enum([
+  "fatal",
+  "error",
+  "warn",
+  "info",
+  "debug",
+  "trace",
+  "silent",
+]);
+
 export const botConfigSchema = z.object({
   bot: z.object({
     defaultModel: z.string().min(1),
@@ -11,6 +21,11 @@ export const botConfigSchema = z.object({
   server: z.object({
     port: z.number().int().min(1),
   }),
+  logging: z
+    .object({
+      level: logLevelSchema.optional(),
+    })
+    .optional(),
 });
 
 export type BotConfig = z.infer<typeof botConfigSchema>;

--- a/src/app/config/config.yaml
+++ b/src/app/config/config.yaml
@@ -5,3 +5,6 @@ bot:
 
 server:
   port: 3000
+
+logging:
+  level: "info"

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,9 +1,9 @@
 import { serve } from "@hono/node-server";
 import { bootstrap } from "@/app/bootstrap";
-import { logger } from "@/shared/utils/logger";
+import { getLogger } from "@/shared/utils/logger";
 
 const { app, port } = bootstrap();
 
 serve({ fetch: app.fetch, port }, (info) => {
-  logger.info(`Server running on http://localhost:${info.port}`);
+  getLogger().info({ port: info.port }, "Server running");
 });

--- a/src/server/hono.test.ts
+++ b/src/server/hono.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@/shared/utils/logger", () => ({
-  logger: { info: vi.fn() },
+  getLogger: vi.fn().mockReturnValue({ info: vi.fn() }),
 }));
 
 describe("createApp", () => {

--- a/src/server/middleware/logger.test.ts
+++ b/src/server/middleware/logger.test.ts
@@ -6,7 +6,7 @@ const UUID_RE =
 
 const mockLog = { info: vi.fn() };
 
-vi.mock("@/shared/utils/logger", () => ({ logger: mockLog }));
+vi.mock("@/shared/utils/logger", () => ({ getLogger: () => mockLog }));
 
 const { logger } = await import("@/server/middleware/logger");
 

--- a/src/server/middleware/logger.ts
+++ b/src/server/middleware/logger.ts
@@ -1,8 +1,9 @@
 import { randomUUID } from "node:crypto";
 import type { MiddlewareHandler } from "hono";
-import { logger as log } from "@/shared/utils/logger";
+import { getLogger } from "@/shared/utils/logger";
 
 export const logger: MiddlewareHandler = async (c, next) => {
+  const log = getLogger();
   const start = Date.now();
   const requestId = randomUUID();
   c.set("requestId", requestId);

--- a/src/shared/utils/logger.test.ts
+++ b/src/shared/utils/logger.test.ts
@@ -14,51 +14,154 @@ vi.mock("@/app/config/env", () => ({
   },
 }));
 
-describe("logger", () => {
-  beforeEach(() => {
-    vi.resetModules();
-    vi.restoreAllMocks();
-    mockPino.mockReset();
-    mockPino.mockReturnValue({ info: vi.fn() });
+function setup() {
+  vi.resetModules();
+  vi.restoreAllMocks();
+  mockPino.mockReset();
+  mockPino.mockReturnValue({ info: vi.fn() });
+  return import("@/shared/utils/logger");
+}
+
+describe("createLogger level", () => {
+  beforeEach(async () => {
+    const { resetLogger } = await setup();
+    resetLogger();
   });
 
-  it("creates logger with pino-pretty transport in development", async () => {
+  it("creates logger with config level when provided", async () => {
+    const { createLogger } = await setup();
+    const { resetLogger } = await import("@/shared/utils/logger");
+    resetLogger();
+
+    createLogger({ level: "debug" });
+
+    expect(mockPino).toHaveBeenCalledWith(
+      expect.objectContaining({ level: "debug" }),
+    );
+  });
+
+  it("falls back to env default when config has no level", async () => {
     mockEnv.NODE_ENV = "development";
+    const { createLogger, resetLogger } = await setup();
+    resetLogger();
 
-    await import("@/shared/utils/logger");
+    createLogger({});
 
     expect(mockPino).toHaveBeenCalledWith(
-      expect.objectContaining({
-        transport: expect.objectContaining({
-          target: "pino-pretty",
-        }),
-      }),
+      expect.objectContaining({ level: "debug" }),
     );
   });
 
-  it("creates logger with pino-pretty transport in test", async () => {
-    mockEnv.NODE_ENV = "test";
-
-    await import("@/shared/utils/logger");
-
-    expect(mockPino).toHaveBeenCalledWith(
-      expect.objectContaining({
-        transport: expect.objectContaining({
-          target: "pino-pretty",
-        }),
-      }),
-    );
-  });
-
-  it("creates logger without transport in production", async () => {
+  it("falls back to env default when config is undefined", async () => {
     mockEnv.NODE_ENV = "production";
+    const { createLogger, resetLogger } = await setup();
+    resetLogger();
 
-    await import("@/shared/utils/logger");
+    createLogger();
+
+    expect(mockPino).toHaveBeenCalledWith(
+      expect.objectContaining({ level: "info" }),
+    );
+  });
+});
+
+describe("createLogger transport", () => {
+  beforeEach(async () => {
+    const { resetLogger } = await setup();
+    resetLogger();
+  });
+
+  it("uses pino-pretty transport in development", async () => {
+    mockEnv.NODE_ENV = "development";
+    const { createLogger, resetLogger } = await setup();
+    resetLogger();
+
+    createLogger();
 
     expect(mockPino).toHaveBeenCalledWith(
       expect.objectContaining({
-        transport: undefined,
+        transport: expect.objectContaining({ target: "pino-pretty" }),
       }),
     );
+  });
+
+  it("uses pino-pretty transport in test", async () => {
+    mockEnv.NODE_ENV = "test";
+    const { createLogger, resetLogger } = await setup();
+    resetLogger();
+
+    createLogger();
+
+    expect(mockPino).toHaveBeenCalledWith(
+      expect.objectContaining({
+        transport: expect.objectContaining({ target: "pino-pretty" }),
+      }),
+    );
+  });
+
+  it("uses no transport in production", async () => {
+    mockEnv.NODE_ENV = "production";
+    const { createLogger, resetLogger } = await setup();
+    resetLogger();
+
+    createLogger();
+
+    expect(mockPino).toHaveBeenCalledWith(
+      expect.objectContaining({ transport: undefined }),
+    );
+  });
+});
+
+describe("getLogger", () => {
+  beforeEach(async () => {
+    const { resetLogger } = await setup();
+    resetLogger();
+  });
+
+  it("returns cached logger after createLogger is called", async () => {
+    mockPino.mockReturnValue({ info: vi.fn(), tag: "first" });
+    const { createLogger, getLogger, resetLogger } = await setup();
+    resetLogger();
+
+    createLogger({ level: "warn" });
+    const logger1 = getLogger();
+    const logger2 = getLogger();
+
+    expect(logger1).toBe(logger2);
+  });
+
+  it("lazily initializes with env defaults", async () => {
+    mockEnv.NODE_ENV = "test";
+    const { getLogger, resetLogger } = await setup();
+    resetLogger();
+
+    getLogger();
+
+    expect(mockPino).toHaveBeenCalledWith(
+      expect.objectContaining({ level: "silent" }),
+    );
+  });
+});
+
+describe("resetLogger", () => {
+  beforeEach(async () => {
+    const { resetLogger } = await setup();
+    resetLogger();
+  });
+
+  it("clears cached logger instance", async () => {
+    const { createLogger, getLogger, resetLogger } = await setup();
+    resetLogger();
+    const first = { info: vi.fn(), tag: "first" };
+    const second = { info: vi.fn(), tag: "second" };
+    mockPino.mockReturnValueOnce(first);
+    mockPino.mockReturnValueOnce(second);
+
+    createLogger();
+    const logger1 = getLogger();
+    resetLogger();
+    const logger2 = getLogger();
+
+    expect(logger1).not.toBe(logger2);
   });
 });

--- a/src/shared/utils/logger.ts
+++ b/src/shared/utils/logger.ts
@@ -10,6 +10,8 @@ function getDefaultLevel(): LevelWithSilent {
       return "debug";
     case "test":
       return "silent";
+    default:
+      return "info";
   }
 }
 
@@ -21,7 +23,7 @@ function getTransportConfig() {
 }
 
 export type LoggerConfig = {
-  level?: string;
+  level?: LevelWithSilent;
 };
 
 let loggerInstance: pino.Logger | null = null;

--- a/src/shared/utils/logger.ts
+++ b/src/shared/utils/logger.ts
@@ -1,9 +1,47 @@
+import type { LevelWithSilent } from "pino";
 import pino from "pino";
 import { env } from "@/app/config/env";
 
-export const logger = pino({
-  transport:
-    env.NODE_ENV === "production"
-      ? undefined
-      : { target: "pino-pretty", options: { colorize: true } },
-});
+function getDefaultLevel(): LevelWithSilent {
+  switch (env.NODE_ENV) {
+    case "production":
+      return "info";
+    case "development":
+      return "debug";
+    case "test":
+      return "silent";
+  }
+}
+
+function getTransportConfig() {
+  if (env.NODE_ENV === "production") {
+    return;
+  }
+  return { target: "pino-pretty", options: { colorize: true } };
+}
+
+export type LoggerConfig = {
+  level?: string;
+};
+
+let loggerInstance: pino.Logger | null = null;
+
+export function createLogger(config?: LoggerConfig): pino.Logger {
+  const level = config?.level ?? getDefaultLevel();
+  loggerInstance = pino({
+    level,
+    transport: getTransportConfig(),
+  });
+  return loggerInstance;
+}
+
+export function getLogger(): pino.Logger {
+  if (!loggerInstance) {
+    return createLogger();
+  }
+  return loggerInstance;
+}
+
+export function resetLogger(): void {
+  loggerInstance = null;
+}


### PR DESCRIPTION
# チケット

close #21

# 概要

ロガーをシングルトンからファクトリパターンにリファクタリングし、`config.yaml` でログレベルを設定可能にしました。

### 主な変更内容

- **ロガーのファクトリパターン化**: `createLogger()` / `getLogger()` / `resetLogger()` の3関数をエクスポートし、`getLogger()` の遅延初期化とキャッシュに対応
- **BotConfigへのloggingセクション追加**: `logLevelSchema` で7段階のログレベルをバリデーション（fatal/error/warn/info/debug/trace/silent）
- **Bootstrapでのロガー初期化**: `bootstrap()` 内で `createLogger(config.logging)` を呼び出し、構造化ログで設定読み込みと起動完了を出力
- **利用箇所の統一**: `logger` 直接参照から `getLogger()` 呼び出しに移行（ミドルウェア・エントリーポイント）
- **テスト追加**: ロガーのレベル決定・トランスポート選択・キャッシュ・リセット、BotConfigのloggingバリデーション、Bootstrapのログ出力をテスト
- **AGENTS.mdにロギング規約を追記**: 利用方法・ログレベルの使い分け・構造化ログ・機密情報の取り扱い

# その他

resolves #21