### PR TITLE
Redis接続インフラとDocker設定を追加

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+node_modules
+dist
+.env
+.git
+.direnv
+coverage
+*.md
+.claude

--- a/.env.example
+++ b/.env.example
@@ -1,1 +1,2 @@
 NODE_ENV=development
+REDIS_URL=redis://localhost:6379

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,24 @@
+FROM node:22-alpine AS builder
+
+RUN corepack enable && corepack prepare pnpm@10.33.0 --activate
+
+WORKDIR /app
+
+COPY package.json pnpm-lock.yaml ./
+RUN pnpm install --frozen-lockfile
+
+COPY . .
+RUN pnpm build
+
+FROM node:22-alpine AS runner
+
+RUN corepack enable && corepack prepare pnpm@10.33.0 --activate
+
+WORKDIR /app
+
+COPY package.json pnpm-lock.yaml ./
+RUN pnpm install --frozen-lockfile --prod
+
+COPY --from=builder /app/dist ./dist
+
+CMD ["node", "dist/index.js"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,23 @@
+services:
+  app:
+    build: .
+    ports:
+      - "3000:3000"
+    environment:
+      - DISCORD_PUBLIC_KEY=${DISCORD_PUBLIC_KEY}
+      - DISCORD_BOT_TOKEN=${DISCORD_BOT_TOKEN}
+      - OPENAI_API_KEY=${OPENAI_API_KEY}
+      - REDIS_URL=redis://redis:6379
+    depends_on:
+      redis:
+        condition: service_healthy
+
+  redis:
+    image: redis:7-alpine
+    ports:
+      - "6379:6379"
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 5s
+      timeout: 3s
+      retries: 5

--- a/src/app/config/bot.config.test.ts
+++ b/src/app/config/bot.config.test.ts
@@ -12,6 +12,8 @@ bot:
   timeoutMs: 30000
 server:
   port: 3000
+redis:
+  url: "redis://localhost:6379"
 `;
 
 describe("botConfigSchema valid", () => {
@@ -202,6 +204,49 @@ describe("botConfigSchema logging invalid", () => {
   });
 });
 
+describe("botConfigSchema redis valid", () => {
+  it("accepts config without redis section", () => {
+    const result = botConfigSchema.parse({
+      bot: { defaultModel: "codex-mini", maxTokens: 4096, timeoutMs: 30000 },
+      server: { port: 3000 },
+    });
+
+    expect(result).not.toHaveProperty("redis");
+  });
+
+  it("accepts valid redis.url", () => {
+    const result = botConfigSchema.parse({
+      bot: { defaultModel: "codex-mini", maxTokens: 4096, timeoutMs: 30000 },
+      server: { port: 3000 },
+      redis: { url: "redis://localhost:6379" },
+    });
+
+    expect(result.redis?.url).toBe("redis://localhost:6379");
+  });
+});
+
+describe("botConfigSchema redis invalid", () => {
+  it("rejects empty string for redis.url", () => {
+    expect(() =>
+      botConfigSchema.parse({
+        bot: { defaultModel: "codex-mini", maxTokens: 4096, timeoutMs: 30000 },
+        server: { port: 3000 },
+        redis: { url: "" },
+      }),
+    ).toThrow();
+  });
+
+  it("rejects non-string redis.url", () => {
+    expect(() =>
+      botConfigSchema.parse({
+        bot: { defaultModel: "codex-mini", maxTokens: 4096, timeoutMs: 30000 },
+        server: { port: 3000 },
+        redis: { url: 123 },
+      }),
+    ).toThrow();
+  });
+});
+
 async function setupLoadConfig(mockValue: string) {
   const { readFileSync } = await import("node:fs");
   vi.mocked(readFileSync).mockReturnValue(mockValue);
@@ -226,6 +271,7 @@ describe("loadConfig", () => {
         timeoutMs: 30000,
       },
       server: { port: 3000 },
+      redis: { url: "redis://localhost:6379" },
     });
   });
 

--- a/src/app/config/bot.config.ts
+++ b/src/app/config/bot.config.ts
@@ -26,6 +26,11 @@ export const botConfigSchema = z.object({
       level: logLevelSchema.optional(),
     })
     .optional(),
+  redis: z
+    .object({
+      url: z.string().min(1),
+    })
+    .optional(),
 });
 
 export type BotConfig = z.infer<typeof botConfigSchema>;

--- a/src/app/config/config.yaml
+++ b/src/app/config/config.yaml
@@ -8,3 +8,6 @@ server:
 
 logging:
   level: "info"
+
+redis:
+  url: "redis://localhost:6379"

--- a/src/app/config/env.test.ts
+++ b/src/app/config/env.test.ts
@@ -1,13 +1,17 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-describe("env", () => {
-  const originalEnv = process.env;
+const originalEnv = process.env;
 
+function setupEnv() {
   beforeEach(() => {
     vi.resetModules();
     vi.restoreAllMocks();
     process.env = { ...originalEnv };
   });
+}
+
+describe("env NODE_ENV", () => {
+  setupEnv();
 
   it('defaults NODE_ENV to "development" when not set', async () => {
     delete process.env.NODE_ENV;
@@ -51,5 +55,34 @@ describe("env", () => {
     process.env.NODE_ENV = "";
 
     await expect(import("@/app/config/env")).rejects.toThrow();
+  });
+});
+
+describe("env REDIS_URL", () => {
+  setupEnv();
+
+  it("parses REDIS_URL when set", async () => {
+    process.env.NODE_ENV = "test";
+    process.env.REDIS_URL = "redis://localhost:6379";
+
+    const { env } = await import("@/app/config/env");
+
+    expect(env.REDIS_URL).toBe("redis://localhost:6379");
+  });
+
+  it("returns undefined for REDIS_URL when not set", async () => {
+    delete process.env.REDIS_URL;
+
+    const { env } = await import("@/app/config/env");
+
+    expect(env.REDIS_URL).toBeUndefined();
+  });
+
+  it("accepts empty string for REDIS_URL", async () => {
+    process.env.REDIS_URL = "";
+
+    const { env } = await import("@/app/config/env");
+
+    expect(env.REDIS_URL).toBe("");
   });
 });

--- a/src/app/config/env.ts
+++ b/src/app/config/env.ts
@@ -4,6 +4,7 @@ const envSchema = z.object({
   NODE_ENV: z
     .enum(["development", "production", "test"])
     .default("development"),
+  REDIS_URL: z.string().optional(),
 });
 
 export const env = envSchema.parse(process.env);

--- a/src/infrastructure/redis/redis.client.test.ts
+++ b/src/infrastructure/redis/redis.client.test.ts
@@ -76,6 +76,12 @@ describe("RedisClient connect success", () => {
     await client.connect();
     expect(mockOn).toHaveBeenCalledWith("reconnecting", expect.any(Function));
   });
+
+  it("registers ready event handler", async () => {
+    const client = await createClient();
+    await client.connect();
+    expect(mockOn).toHaveBeenCalledWith("ready", expect.any(Function));
+  });
 });
 
 describe("RedisClient connect failure", () => {
@@ -117,6 +123,68 @@ describe("RedisClient error event", () => {
     errorHandler?.(new Error("connection lost"));
     expect(client.isConnected).toBe(false);
   });
+
+  it("logs error on error event", async () => {
+    const client = await createClient();
+    await client.connect();
+    const errorHandler = mockOn.mock.calls.find(
+      (c: string[]) => c[0] === "error",
+    )?.[1];
+    errorHandler?.(new Error("connection lost"));
+    expect(mockLogError).toHaveBeenCalledWith(
+      { err: "connection lost" },
+      "Redis error",
+    );
+  });
+});
+
+describe("RedisClient reconnecting event", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setupConnectedClient();
+  });
+
+  it("logs warn on reconnecting event", async () => {
+    const client = await createClient();
+    await client.connect();
+    const reconnectingHandler = mockOn.mock.calls.find(
+      (c: string[]) => c[0] === "reconnecting",
+    )?.[1];
+    reconnectingHandler?.();
+    expect(mockLogWarn).toHaveBeenCalledWith("Redis reconnecting...");
+  });
+});
+
+describe("RedisClient ready event", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setupConnectedClient();
+  });
+
+  it("sets connected to true on ready event", async () => {
+    const client = await createClient();
+    await client.connect();
+    const errorHandler = mockOn.mock.calls.find(
+      (c: string[]) => c[0] === "error",
+    )?.[1];
+    errorHandler?.(new Error("connection lost"));
+    expect(client.isConnected).toBe(false);
+    const readyHandler = mockOn.mock.calls.find(
+      (c: string[]) => c[0] === "ready",
+    )?.[1];
+    readyHandler?.();
+    expect(client.isConnected).toBe(true);
+  });
+
+  it("logs info on ready event", async () => {
+    const client = await createClient();
+    await client.connect();
+    const readyHandler = mockOn.mock.calls.find(
+      (c: string[]) => c[0] === "ready",
+    )?.[1];
+    readyHandler?.();
+    expect(mockLogInfo).toHaveBeenCalledWith("Redis reconnected and ready");
+  });
 });
 
 describe("RedisClient disconnect", () => {
@@ -144,6 +212,22 @@ describe("RedisClient disconnect", () => {
     const client = await createClient();
     await client.disconnect();
     expect(mockQuit).not.toHaveBeenCalled();
+  });
+
+  it("cleans up when quit throws", async () => {
+    mockQuit.mockRejectedValue(new Error("already closed"));
+    const client = await createClient();
+    await client.connect();
+    await client.disconnect();
+    expect(client.isConnected).toBe(false);
+  });
+
+  it("logs info when quit throws", async () => {
+    mockQuit.mockRejectedValue(new Error("already closed"));
+    const client = await createClient();
+    await client.connect();
+    await client.disconnect();
+    expect(mockLogInfo).toHaveBeenCalledWith("Redis disconnected");
   });
 });
 

--- a/src/infrastructure/redis/redis.client.test.ts
+++ b/src/infrastructure/redis/redis.client.test.ts
@@ -1,0 +1,410 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockConnect = vi.fn();
+const mockQuit = vi.fn();
+const mockGet = vi.fn();
+const mockSet = vi.fn();
+const mockSetEx = vi.fn();
+const mockDel = vi.fn();
+const mockPing = vi.fn();
+const mockOn = vi.fn();
+
+vi.mock("redis", () => ({
+  createClient: vi.fn().mockReturnValue({
+    connect: mockConnect,
+    quit: mockQuit,
+    get: mockGet,
+    set: mockSet,
+    setEx: mockSetEx,
+    del: mockDel,
+    ping: mockPing,
+    on: mockOn,
+  }),
+}));
+
+const mockLogInfo = vi.fn();
+const mockLogWarn = vi.fn();
+const mockLogError = vi.fn();
+
+vi.mock("@/shared/utils/logger", () => ({
+  getLogger: vi.fn().mockReturnValue({
+    info: mockLogInfo,
+    warn: mockLogWarn,
+    error: mockLogError,
+  }),
+}));
+
+async function createClient() {
+  const { RedisClient } = await import("./redis.client");
+  return new RedisClient("redis://localhost:6379");
+}
+
+function setupConnectedClient() {
+  mockConnect.mockResolvedValue(undefined);
+  mockOn.mockReturnValue(undefined);
+}
+
+describe("RedisClient connect success", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setupConnectedClient();
+  });
+
+  it("connects and sets isConnected to true", async () => {
+    const client = await createClient();
+    await client.connect();
+    expect(client.isConnected).toBe(true);
+  });
+
+  it("logs info on successful connection", async () => {
+    const client = await createClient();
+    await client.connect();
+    expect(mockLogInfo).toHaveBeenCalledWith(
+      { url: "redis://localhost:6379" },
+      "Redis connected",
+    );
+  });
+
+  it("registers error event handler", async () => {
+    const client = await createClient();
+    await client.connect();
+    expect(mockOn).toHaveBeenCalledWith("error", expect.any(Function));
+  });
+
+  it("registers reconnecting event handler", async () => {
+    const client = await createClient();
+    await client.connect();
+    expect(mockOn).toHaveBeenCalledWith("reconnecting", expect.any(Function));
+  });
+});
+
+describe("RedisClient connect failure", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockConnect.mockRejectedValue(new Error("ECONNREFUSED"));
+    mockOn.mockReturnValue(undefined);
+  });
+
+  it("falls back on connection failure", async () => {
+    const client = await createClient();
+    await client.connect();
+    expect(client.isConnected).toBe(false);
+  });
+
+  it("logs warn on connection failure", async () => {
+    const client = await createClient();
+    await client.connect();
+    expect(mockLogWarn).toHaveBeenCalledWith(
+      { err: expect.any(Error) },
+      "Redis connection failed, falling back to in-memory",
+    );
+  });
+});
+
+describe("RedisClient error event", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setupConnectedClient();
+  });
+
+  it("sets connected to false on error event", async () => {
+    const client = await createClient();
+    await client.connect();
+    expect(client.isConnected).toBe(true);
+    const errorHandler = mockOn.mock.calls.find(
+      (c: string[]) => c[0] === "error",
+    )?.[1];
+    errorHandler?.(new Error("connection lost"));
+    expect(client.isConnected).toBe(false);
+  });
+});
+
+describe("RedisClient disconnect", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setupConnectedClient();
+    mockQuit.mockResolvedValue(undefined);
+  });
+
+  it("disconnects connected client", async () => {
+    const client = await createClient();
+    await client.connect();
+    await client.disconnect();
+    expect(client.isConnected).toBe(false);
+  });
+
+  it("calls quit on the redis client", async () => {
+    const client = await createClient();
+    await client.connect();
+    await client.disconnect();
+    expect(mockQuit).toHaveBeenCalled();
+  });
+
+  it("is no-op when not connected", async () => {
+    const client = await createClient();
+    await client.disconnect();
+    expect(mockQuit).not.toHaveBeenCalled();
+  });
+});
+
+describe("RedisClient get from redis", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setupConnectedClient();
+    mockGet.mockResolvedValue("value-from-redis");
+    mockSet.mockResolvedValue("OK");
+  });
+
+  it("returns value from redis when connected", async () => {
+    const client = await createClient();
+    await client.connect();
+    expect(await client.get("key")).toBe("value-from-redis");
+  });
+
+  it("returns null for missing key from redis", async () => {
+    mockGet.mockResolvedValue(null);
+    const client = await createClient();
+    await client.connect();
+    expect(await client.get("missing")).toBeNull();
+  });
+
+  it("falls back when redis throws", async () => {
+    mockSet.mockRejectedValue(new Error("redis error"));
+    mockGet.mockRejectedValue(new Error("redis error"));
+    const client = await createClient();
+    await client.connect();
+    await client.set("key", "fallback-value");
+    expect(await client.get("key")).toBe("fallback-value");
+  });
+});
+
+describe("RedisClient get fallback", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns value from fallback when not connected", async () => {
+    const client = await createClient();
+    await client.set("key", "in-memory-value");
+    expect(await client.get("key")).toBe("in-memory-value");
+  });
+
+  it("returns null for missing fallback key", async () => {
+    const client = await createClient();
+    expect(await client.get("nonexistent")).toBeNull();
+  });
+
+  it("returns null and deletes expired entry", async () => {
+    vi.useFakeTimers();
+    const client = await createClient();
+    await client.set("key", "value", { ttlMs: 1000 });
+    vi.advanceTimersByTime(1001);
+    expect(await client.get("key")).toBeNull();
+    vi.useRealTimers();
+  });
+});
+
+describe("RedisClient set to redis", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setupConnectedClient();
+    mockSet.mockResolvedValue("OK");
+    mockSetEx.mockResolvedValue("OK");
+  });
+
+  it("calls client.set without TTL", async () => {
+    const client = await createClient();
+    await client.connect();
+    await client.set("key", "value");
+    expect(mockSet).toHaveBeenCalledWith("key", "value");
+  });
+
+  it("calls client.setEx with TTL in seconds", async () => {
+    const client = await createClient();
+    await client.connect();
+    await client.set("key", "value", { ttlMs: 5000 });
+    expect(mockSetEx).toHaveBeenCalledWith("key", 5, "value");
+  });
+
+  it("falls back when redis throws on set", async () => {
+    mockSet.mockRejectedValue(new Error("redis error"));
+    const client = await createClient();
+    await client.connect();
+    await client.set("key", "fallback-value");
+    expect(await client.get("key")).toBe("fallback-value");
+  });
+
+  it("calls client.set instead of setEx when ttlMs is 0", async () => {
+    const client = await createClient();
+    await client.connect();
+    await client.set("key", "value", { ttlMs: 0 });
+    expect(mockSet).toHaveBeenCalledWith("key", "value");
+    expect(mockSetEx).not.toHaveBeenCalled();
+  });
+});
+
+describe("RedisClient set fallback", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("stores in fallback when not connected", async () => {
+    const client = await createClient();
+    await client.set("key", "value");
+    expect(await client.get("key")).toBe("value");
+  });
+});
+
+describe("RedisClient delete", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setupConnectedClient();
+    mockSet.mockResolvedValue("OK");
+    mockDel.mockResolvedValue(1);
+  });
+
+  it("deletes from redis and fallback when connected", async () => {
+    const client = await createClient();
+    await client.connect();
+    await client.set("key", "value");
+    await client.delete("key");
+    expect(mockDel).toHaveBeenCalledWith("key");
+    expect(await client.get("key")).toBeNull();
+  });
+
+  it("deletes from fallback only when not connected", async () => {
+    const client = await createClient();
+    await client.set("key", "value");
+    await client.delete("key");
+    expect(await client.get("key")).toBeNull();
+  });
+
+  it("does not throw on non-existent key", async () => {
+    const client = await createClient();
+    await expect(client.delete("nonexistent")).resolves.toBeUndefined();
+  });
+
+  it("still deletes from fallback when redis del throws", async () => {
+    mockDel.mockRejectedValue(new Error("redis error"));
+    const client = await createClient();
+    await client.connect();
+    await client.set("key", "value");
+    await client.delete("key");
+    expect(await client.get("key")).toBeNull();
+  });
+});
+
+describe("RedisClient ping", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setupConnectedClient();
+    mockPing.mockResolvedValue("PONG");
+  });
+
+  it("returns true when connected and PONG received", async () => {
+    const client = await createClient();
+    await client.connect();
+    expect(await client.ping()).toBe(true);
+  });
+
+  it("returns false when not connected", async () => {
+    const client = await createClient();
+    expect(await client.ping()).toBe(false);
+  });
+
+  it("returns false when ping throws", async () => {
+    mockPing.mockRejectedValue(new Error("timeout"));
+    const client = await createClient();
+    await client.connect();
+    expect(await client.ping()).toBe(false);
+  });
+});
+
+describe("RedisClient isConnected", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setupConnectedClient();
+    mockQuit.mockResolvedValue(undefined);
+  });
+
+  it("returns false initially", async () => {
+    const client = await createClient();
+    expect(client.isConnected).toBe(false);
+  });
+
+  it("returns true after connect", async () => {
+    const client = await createClient();
+    await client.connect();
+    expect(client.isConnected).toBe(true);
+  });
+
+  it("returns false after disconnect", async () => {
+    const client = await createClient();
+    await client.connect();
+    await client.disconnect();
+    expect(client.isConnected).toBe(false);
+  });
+});
+
+describe("RedisClient fallback TTL", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("returns value before expiry", async () => {
+    vi.useFakeTimers();
+    const client = await createClient();
+    await client.set("key", "value", { ttlMs: 10000 });
+    vi.advanceTimersByTime(5000);
+    expect(await client.get("key")).toBe("value");
+  });
+
+  it("returns null after expiry", async () => {
+    vi.useFakeTimers();
+    const client = await createClient();
+    await client.set("key", "value", { ttlMs: 1000 });
+    vi.advanceTimersByTime(1001);
+    expect(await client.get("key")).toBeNull();
+  });
+
+  it("keeps permanent entry without TTL", async () => {
+    vi.useFakeTimers();
+    const client = await createClient();
+    await client.set("key", "value");
+    vi.advanceTimersByTime(86400000);
+    expect(await client.get("key")).toBe("value");
+  });
+});
+
+describe("RedisClient setEx TTL boundary", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setupConnectedClient();
+    mockSetEx.mockResolvedValue("OK");
+  });
+
+  it("ceils ttlMs 1 to 1 second", async () => {
+    const client = await createClient();
+    await client.connect();
+    await client.set("key", "value", { ttlMs: 1 });
+    expect(mockSetEx).toHaveBeenCalledWith("key", 1, "value");
+  });
+
+  it("ceils ttlMs 999 to 1 second", async () => {
+    const client = await createClient();
+    await client.connect();
+    await client.set("key", "value", { ttlMs: 999 });
+    expect(mockSetEx).toHaveBeenCalledWith("key", 1, "value");
+  });
+
+  it("ceils ttlMs 1001 to 2 seconds", async () => {
+    const client = await createClient();
+    await client.connect();
+    await client.set("key", "value", { ttlMs: 1001 });
+    expect(mockSetEx).toHaveBeenCalledWith("key", 2, "value");
+  });
+});

--- a/src/infrastructure/redis/redis.client.ts
+++ b/src/infrastructure/redis/redis.client.ts
@@ -20,6 +20,10 @@ export class RedisClient {
       this.client.on("reconnecting", () => {
         getLogger().warn("Redis reconnecting...");
       });
+      this.client.on("ready", () => {
+        this.connected = true;
+        getLogger().info("Redis reconnected and ready");
+      });
       await this.client.connect();
       this.connected = true;
       getLogger().info({ url: this.url }, "Redis connected");
@@ -28,16 +32,22 @@ export class RedisClient {
         { err },
         "Redis connection failed, falling back to in-memory",
       );
+      this.client = null;
       this.connected = false;
     }
   }
 
   async disconnect(): Promise<void> {
     if (this.client) {
-      await this.client.quit();
-      this.client = null;
-      this.connected = false;
-      getLogger().info("Redis disconnected");
+      try {
+        await this.client.quit();
+      } catch {
+        // 接続が既に切断されている場合は無視
+      } finally {
+        this.client = null;
+        this.connected = false;
+        getLogger().info("Redis disconnected");
+      }
     }
   }
 

--- a/src/infrastructure/redis/redis.client.ts
+++ b/src/infrastructure/redis/redis.client.ts
@@ -1,0 +1,112 @@
+import { createClient, type RedisClientType } from "redis";
+import { getLogger } from "@/shared/utils/logger";
+
+type FallbackEntry = { value: string; expiresAt?: number };
+
+export class RedisClient {
+  private client: RedisClientType | null = null;
+  private fallback = new Map<string, FallbackEntry>();
+  private connected = false;
+
+  constructor(private url: string) {}
+
+  async connect(): Promise<void> {
+    try {
+      this.client = createClient({ url: this.url });
+      this.client.on("error", (err) => {
+        getLogger().error({ err: err.message }, "Redis error");
+        this.connected = false;
+      });
+      this.client.on("reconnecting", () => {
+        getLogger().warn("Redis reconnecting...");
+      });
+      await this.client.connect();
+      this.connected = true;
+      getLogger().info({ url: this.url }, "Redis connected");
+    } catch (err) {
+      getLogger().warn(
+        { err },
+        "Redis connection failed, falling back to in-memory",
+      );
+      this.connected = false;
+    }
+  }
+
+  async disconnect(): Promise<void> {
+    if (this.client) {
+      await this.client.quit();
+      this.client = null;
+      this.connected = false;
+      getLogger().info("Redis disconnected");
+    }
+  }
+
+  async get(key: string): Promise<string | null> {
+    if (this.client && this.connected) {
+      try {
+        return await this.client.get(key);
+      } catch {
+        return this.fallbackGet(key);
+      }
+    }
+    return this.fallbackGet(key);
+  }
+
+  async set(
+    key: string,
+    value: string,
+    opts?: { ttlMs?: number },
+  ): Promise<void> {
+    if (this.client && this.connected) {
+      try {
+        if (opts?.ttlMs) {
+          await this.client.setEx(key, Math.ceil(opts.ttlMs / 1000), value);
+        } else {
+          await this.client.set(key, value);
+        }
+        return;
+      } catch {
+        // fallthrough to fallback
+      }
+    }
+    this.fallback.set(key, {
+      value,
+      expiresAt: opts?.ttlMs ? Date.now() + opts.ttlMs : undefined,
+    });
+  }
+
+  async delete(key: string): Promise<void> {
+    if (this.client && this.connected) {
+      try {
+        await this.client.del(key);
+      } catch {
+        // noop
+      }
+    }
+    this.fallback.delete(key);
+  }
+
+  async ping(): Promise<boolean> {
+    if (!(this.client && this.connected)) return false;
+    try {
+      const result = await this.client.ping();
+      return result === "PONG";
+    } catch {
+      return false;
+    }
+  }
+
+  get isConnected(): boolean {
+    return this.connected;
+  }
+
+  private fallbackGet(key: string): string | null {
+    const entry = this.fallback.get(key);
+    if (!entry) return null;
+    if (entry.expiresAt && Date.now() > entry.expiresAt) {
+      this.fallback.delete(key);
+      return null;
+    }
+    return entry.value;
+  }
+}


### PR DESCRIPTION
# チケット

close #10

# 概要

Redis接続インフラストラクチャとDocker開発環境を追加しました。

### 変更内容

- **BotConfigにredis設定セクションを追加**: `botConfigSchema`にオプションの`redis.url`を追加し、YAML設定ファイルにも反映
- **環境変数REDIS_URLのバリデーションを追加**: `envSchema`に`REDIS_URL`（任意）を追加
- **Redis接続クライアントを実装**: `RedisClient`クラスを追加。接続失敗時は自動的にインメモリフォールバックに切り替わり、TTL付きset/get/delete/ping/isConnectedをサポート
- **Docker設定ファイルを追加**: マルチステージビルドのDockerfile、docker-compose.yml（app + Redis 7 Alpine）、.dockerignoreを追加

# その他

resolves #10