### PR TITLE
実装: server/ — Honoサーバー・ミドルウェア・Gateway

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,3 @@
 NODE_ENV=development
 REDIS_URL=redis://localhost:6379
+OPENAI_API_KEY=your-api-key

--- a/src/app/bootstrap.test.ts
+++ b/src/app/bootstrap.test.ts
@@ -3,21 +3,57 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 const mockCreateLogger = vi.fn();
 const mockInfo = vi.fn();
 const mockDebug = vi.fn();
+const mockWarn = vi.fn();
 
 vi.mock("@/shared/utils/logger", () => ({
   createLogger: (...args: unknown[]) => mockCreateLogger(...args),
   getLogger: vi.fn().mockReturnValue({
     info: (...args: unknown[]) => mockInfo(...args),
     debug: (...args: unknown[]) => mockDebug(...args),
+    warn: (...args: unknown[]) => mockWarn(...args),
   }),
 }));
 
-function setupMocks(config: Record<string, unknown>) {
+const mockCreateApp = vi.fn().mockReturnValue({ fetch: vi.fn() });
+const mockStart = vi.fn().mockResolvedValue(undefined);
+
+function setupMocks(
+  config: Record<string, unknown>,
+  envOverrides?: Record<string, unknown>,
+) {
   vi.doMock("@/app/config/bot.config", () => ({
     loadConfig: vi.fn().mockReturnValue(config),
   }));
+  vi.doMock("@/app/config/env", () => ({
+    env: {
+      NODE_ENV: "test",
+      OPENAI_API_KEY: "test-key",
+      DISCORD_PUBLIC_KEY: "test-pk",
+      DISCORD_BOT_TOKEN: undefined,
+      DISCORD_APPLICATION_ID: undefined,
+      ...envOverrides,
+    },
+  }));
   vi.doMock("@/server/hono", () => ({
-    createApp: vi.fn().mockReturnValue({ fetch: vi.fn() }),
+    createApp: mockCreateApp,
+  }));
+  vi.doMock("@/server/gateway/discord.gateway", () => ({
+    // biome-ignore lint/complexity/useArrowFunction: constructor mock requires function
+    DiscordGateway: vi.fn().mockImplementation(function () {
+      return { start: mockStart, stop: vi.fn() };
+    }),
+  }));
+  vi.doMock("@/infrastructure/redis/redis.client", () => ({
+    // biome-ignore lint/complexity/useArrowFunction: constructor mock requires function
+    RedisClient: vi.fn().mockImplementation(function () {
+      return { connect: vi.fn().mockResolvedValue(undefined) };
+    }),
+  }));
+  vi.doMock("@/ai/client/codex.client", () => ({
+    // biome-ignore lint/complexity/useArrowFunction: constructor mock requires function
+    CodexClient: vi.fn().mockImplementation(function () {
+      return {};
+    }),
   }));
 }
 
@@ -25,6 +61,8 @@ describe("bootstrap result", () => {
   beforeEach(() => {
     vi.resetModules();
     vi.restoreAllMocks();
+    mockCreateApp.mockClear();
+    mockCreateApp.mockReturnValue({ fetch: vi.fn() });
   });
 
   it("returns app with fetch method and port from config", async () => {
@@ -40,6 +78,64 @@ describe("bootstrap result", () => {
 
     expect(typeof result.app.fetch).toBe("function");
     expect(result.port).toBe(3000);
+  });
+
+  it("passes interactionHandler to createApp", async () => {
+    setupMocks({
+      bot: { defaultModel: "codex-mini", maxTokens: 4096, timeoutMs: 30000 },
+      server: { port: 3000 },
+      logging: { level: "info" },
+    });
+
+    const { bootstrap } = await import("@/app/bootstrap");
+
+    bootstrap();
+
+    expect(mockCreateApp).toHaveBeenCalledWith(
+      expect.objectContaining({ interactionHandler: expect.any(Object) }),
+    );
+  });
+});
+
+describe("bootstrap gateway", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.restoreAllMocks();
+    mockCreateApp.mockClear();
+    mockCreateApp.mockReturnValue({ fetch: vi.fn() });
+  });
+
+  it("returns null gateway when DISCORD_BOT_TOKEN is not set", async () => {
+    setupMocks({
+      bot: { defaultModel: "codex-mini", maxTokens: 4096, timeoutMs: 30000 },
+      server: { port: 3000 },
+      logging: { level: "info" },
+    });
+
+    const { bootstrap } = await import("@/app/bootstrap");
+
+    const result = bootstrap();
+
+    expect(result.gateway).toBeNull();
+  });
+
+  it("returns gateway when DISCORD_BOT_TOKEN is set", async () => {
+    setupMocks(
+      {
+        bot: { defaultModel: "codex-mini", maxTokens: 4096, timeoutMs: 30000 },
+        server: { port: 3000 },
+        logging: { level: "info" },
+      },
+      { DISCORD_BOT_TOKEN: "test-bot-token" },
+    );
+
+    const { bootstrap } = await import("@/app/bootstrap");
+
+    const result = bootstrap();
+
+    expect(result.gateway).not.toBeNull();
+    expect(result.gateway).toHaveProperty("start");
+    expect(result.gateway).toHaveProperty("stop");
   });
 });
 

--- a/src/app/bootstrap.test.ts
+++ b/src/app/bootstrap.test.ts
@@ -200,4 +200,19 @@ describe("bootstrap error", () => {
 
     expect(() => bootstrap()).toThrow("config error");
   });
+
+  it("throws when OPENAI_API_KEY is not set", async () => {
+    setupMocks(
+      {
+        bot: { defaultModel: "codex-mini", maxTokens: 4096, timeoutMs: 30000 },
+        server: { port: 3000 },
+        logging: { level: "info" },
+      },
+      { OPENAI_API_KEY: undefined },
+    );
+
+    const { bootstrap } = await import("@/app/bootstrap");
+
+    expect(() => bootstrap()).toThrow("OPENAI_API_KEY is required");
+  });
 });

--- a/src/app/bootstrap.ts
+++ b/src/app/bootstrap.ts
@@ -24,7 +24,11 @@ export function bootstrap() {
     log.warn({ err: String(err) }, "Redis connection failed");
   });
 
-  const codex = new CodexClient(env.OPENAI_API_KEY ?? "");
+  const apiKey = env.OPENAI_API_KEY;
+  if (!apiKey) {
+    throw new Error("OPENAI_API_KEY is required");
+  }
+  const codex = new CodexClient(apiKey);
   const aiService = new AIService(codex, redis);
 
   const commands = [new PingCommand(), new ChatCommand(aiService)];

--- a/src/app/bootstrap.ts
+++ b/src/app/bootstrap.ts
@@ -1,4 +1,13 @@
+import { CodexClient } from "@/ai/client/codex.client";
+import { AIService } from "@/ai/services/ai.service";
 import { loadConfig } from "@/app/config/bot.config";
+import { env } from "@/app/config/env";
+import { ChatCommand } from "@/bot/commands/ai/chat.command";
+import { PingCommand } from "@/bot/commands/utility/ping.command";
+import { InteractionHandler } from "@/bot/handlers/interaction.handler";
+import { Router } from "@/bot/router";
+import { RedisClient } from "@/infrastructure/redis/redis.client";
+import { DiscordGateway } from "@/server/gateway/discord.gateway";
 import { createApp } from "@/server/hono";
 import { createLogger, getLogger } from "@/shared/utils/logger";
 
@@ -9,12 +18,31 @@ export function bootstrap() {
 
   const log = getLogger();
   log.debug({ config }, "Config loaded");
+
+  const redis = new RedisClient(config.redis?.url ?? "redis://localhost:6379");
+  redis.connect().catch((err) => {
+    log.warn({ err: String(err) }, "Redis connection failed");
+  });
+
+  const codex = new CodexClient(env.OPENAI_API_KEY ?? "");
+  const aiService = new AIService(codex, redis);
+
+  const commands = [new PingCommand(), new ChatCommand(aiService)];
+  const router = new Router(commands);
+  const interactionHandler = new InteractionHandler(router);
+
+  const app = createApp({ interactionHandler });
+
+  let gateway: DiscordGateway | null = null;
+  if (env.DISCORD_BOT_TOKEN) {
+    gateway = new DiscordGateway();
+    const webhookUrl = `http://localhost:${config.server.port}/api/webhooks/discord`;
+    gateway.start(webhookUrl).catch((err) => {
+      log.error({ err: String(err) }, "Gateway startup failed");
+    });
+  }
+
   log.info({ port: config.server.port }, "Bootstrap completed");
 
-  const app = createApp();
-
-  return {
-    app,
-    port: config.server.port,
-  };
+  return { app, port: config.server.port, gateway };
 }

--- a/src/app/config/env.test.ts
+++ b/src/app/config/env.test.ts
@@ -86,3 +86,87 @@ describe("env REDIS_URL", () => {
     expect(env.REDIS_URL).toBe("");
   });
 });
+
+describe("env OPENAI_API_KEY", () => {
+  setupEnv();
+
+  it("parses OPENAI_API_KEY when set", async () => {
+    process.env.NODE_ENV = "test";
+    process.env.OPENAI_API_KEY = "sk-test-key";
+
+    const { env } = await import("@/app/config/env");
+
+    expect(env.OPENAI_API_KEY).toBe("sk-test-key");
+  });
+
+  it("returns undefined when not set", async () => {
+    delete process.env.OPENAI_API_KEY;
+
+    const { env } = await import("@/app/config/env");
+
+    expect(env.OPENAI_API_KEY).toBeUndefined();
+  });
+});
+
+describe("env DISCORD_PUBLIC_KEY", () => {
+  setupEnv();
+
+  it("parses DISCORD_PUBLIC_KEY when set", async () => {
+    process.env.NODE_ENV = "test";
+    process.env.DISCORD_PUBLIC_KEY = "abc123";
+
+    const { env } = await import("@/app/config/env");
+
+    expect(env.DISCORD_PUBLIC_KEY).toBe("abc123");
+  });
+
+  it("returns undefined when not set", async () => {
+    delete process.env.DISCORD_PUBLIC_KEY;
+
+    const { env } = await import("@/app/config/env");
+
+    expect(env.DISCORD_PUBLIC_KEY).toBeUndefined();
+  });
+});
+
+describe("env DISCORD_BOT_TOKEN", () => {
+  setupEnv();
+
+  it("parses DISCORD_BOT_TOKEN when set", async () => {
+    process.env.NODE_ENV = "test";
+    process.env.DISCORD_BOT_TOKEN = "bot-token";
+
+    const { env } = await import("@/app/config/env");
+
+    expect(env.DISCORD_BOT_TOKEN).toBe("bot-token");
+  });
+
+  it("returns undefined when not set", async () => {
+    delete process.env.DISCORD_BOT_TOKEN;
+
+    const { env } = await import("@/app/config/env");
+
+    expect(env.DISCORD_BOT_TOKEN).toBeUndefined();
+  });
+});
+
+describe("env DISCORD_APPLICATION_ID", () => {
+  setupEnv();
+
+  it("parses DISCORD_APPLICATION_ID when set", async () => {
+    process.env.NODE_ENV = "test";
+    process.env.DISCORD_APPLICATION_ID = "app-id";
+
+    const { env } = await import("@/app/config/env");
+
+    expect(env.DISCORD_APPLICATION_ID).toBe("app-id");
+  });
+
+  it("returns undefined when not set", async () => {
+    delete process.env.DISCORD_APPLICATION_ID;
+
+    const { env } = await import("@/app/config/env");
+
+    expect(env.DISCORD_APPLICATION_ID).toBeUndefined();
+  });
+});

--- a/src/app/config/env.ts
+++ b/src/app/config/env.ts
@@ -5,6 +5,10 @@ const envSchema = z.object({
     .enum(["development", "production", "test"])
     .default("development"),
   REDIS_URL: z.string().optional(),
+  OPENAI_API_KEY: z.string().optional(),
+  DISCORD_PUBLIC_KEY: z.string().optional(),
+  DISCORD_BOT_TOKEN: z.string().optional(),
+  DISCORD_APPLICATION_ID: z.string().optional(),
 });
 
 export const env = envSchema.parse(process.env);

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,11 +11,10 @@ const server = serve({ fetch: app.fetch, port }, (info) => {
 function shutdown() {
   getLogger().info("Shutting down");
   gateway?.stop();
-  server.close();
+  server.close(() => {
+    process.exit(0);
+  });
 }
 
 process.on("SIGTERM", shutdown);
-process.on("SIGINT", () => {
-  shutdown();
-  process.exit(0);
-});
+process.on("SIGINT", shutdown);

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,8 +2,20 @@ import { serve } from "@hono/node-server";
 import { bootstrap } from "@/app/bootstrap";
 import { getLogger } from "@/shared/utils/logger";
 
-const { app, port } = bootstrap();
+const { app, port, gateway } = bootstrap();
 
-serve({ fetch: app.fetch, port }, (info) => {
+const server = serve({ fetch: app.fetch, port }, (info) => {
   getLogger().info({ port: info.port }, "Server running");
+});
+
+function shutdown() {
+  getLogger().info("Shutting down");
+  gateway?.stop();
+  server.close();
+}
+
+process.on("SIGTERM", shutdown);
+process.on("SIGINT", () => {
+  shutdown();
+  process.exit(0);
 });

--- a/src/server/gateway/discord.gateway.test.ts
+++ b/src/server/gateway/discord.gateway.test.ts
@@ -1,0 +1,165 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockLog = {
+  info: vi.fn(),
+  error: vi.fn(),
+  warn: vi.fn(),
+  debug: vi.fn(),
+};
+
+vi.mock("@/shared/utils/logger", () => ({ getLogger: () => mockLog }));
+
+const mockEnv: Record<string, string | undefined> = {
+  DISCORD_BOT_TOKEN: "test-token",
+  DISCORD_PUBLIC_KEY: "test-key",
+  DISCORD_APPLICATION_ID: "test-app-id",
+};
+
+vi.mock("@/app/config/env", () => ({
+  get env() {
+    return mockEnv;
+  },
+}));
+
+const mockStartGatewayListener = vi.fn().mockResolvedValue(new Response());
+const mockCreateDiscordAdapter = vi.fn().mockReturnValue({
+  startGatewayListener: mockStartGatewayListener,
+});
+
+vi.mock("@chat-adapter/discord", () => ({
+  createDiscordAdapter: (...args: unknown[]) =>
+    mockCreateDiscordAdapter(...args),
+}));
+
+const { DiscordGateway } = await import("@/server/gateway/discord.gateway");
+
+function resetMocks() {
+  vi.restoreAllMocks();
+  mockLog.info.mockReset();
+  mockLog.error.mockReset();
+  mockCreateDiscordAdapter.mockClear();
+  mockStartGatewayListener.mockClear();
+  mockStartGatewayListener.mockResolvedValue(new Response());
+  mockEnv.DISCORD_BOT_TOKEN = "test-token";
+  mockEnv.DISCORD_PUBLIC_KEY = "test-key";
+  mockEnv.DISCORD_APPLICATION_ID = "test-app-id";
+}
+
+describe("DiscordGateway - start validation", () => {
+  beforeEach(resetMocks);
+
+  it("throws when DISCORD_BOT_TOKEN is not configured", async () => {
+    mockEnv.DISCORD_BOT_TOKEN = undefined;
+    const gw = new DiscordGateway();
+
+    await expect(gw.start()).rejects.toThrow(
+      "Gateway requires DISCORD_BOT_TOKEN, DISCORD_PUBLIC_KEY, and DISCORD_APPLICATION_ID",
+    );
+  });
+
+  it("throws when DISCORD_PUBLIC_KEY is not configured", async () => {
+    mockEnv.DISCORD_PUBLIC_KEY = undefined;
+    const gw = new DiscordGateway();
+
+    await expect(gw.start()).rejects.toThrow(
+      "Gateway requires DISCORD_BOT_TOKEN, DISCORD_PUBLIC_KEY, and DISCORD_APPLICATION_ID",
+    );
+  });
+
+  it("throws when DISCORD_APPLICATION_ID is not configured", async () => {
+    mockEnv.DISCORD_APPLICATION_ID = undefined;
+    const gw = new DiscordGateway();
+
+    await expect(gw.start()).rejects.toThrow(
+      "Gateway requires DISCORD_BOT_TOKEN, DISCORD_PUBLIC_KEY, and DISCORD_APPLICATION_ID",
+    );
+  });
+
+  it("throws when DISCORD_BOT_TOKEN is empty string", async () => {
+    mockEnv.DISCORD_BOT_TOKEN = "";
+    const gw = new DiscordGateway();
+
+    await expect(gw.start()).rejects.toThrow(
+      "Gateway requires DISCORD_BOT_TOKEN, DISCORD_PUBLIC_KEY, and DISCORD_APPLICATION_ID",
+    );
+  });
+
+  it("throws when DISCORD_PUBLIC_KEY is empty string", async () => {
+    mockEnv.DISCORD_PUBLIC_KEY = "";
+    const gw = new DiscordGateway();
+
+    await expect(gw.start()).rejects.toThrow(
+      "Gateway requires DISCORD_BOT_TOKEN, DISCORD_PUBLIC_KEY, and DISCORD_APPLICATION_ID",
+    );
+  });
+
+  it("throws when DISCORD_APPLICATION_ID is empty string", async () => {
+    mockEnv.DISCORD_APPLICATION_ID = "";
+    const gw = new DiscordGateway();
+
+    await expect(gw.start()).rejects.toThrow(
+      "Gateway requires DISCORD_BOT_TOKEN, DISCORD_PUBLIC_KEY, and DISCORD_APPLICATION_ID",
+    );
+  });
+});
+
+describe("DiscordGateway - start success", () => {
+  beforeEach(resetMocks);
+
+  it("creates adapter and calls startGatewayListener", async () => {
+    const gw = new DiscordGateway();
+    await gw.start("http://localhost:3000/api/webhooks/discord");
+
+    expect(mockCreateDiscordAdapter).toHaveBeenCalledWith({
+      botToken: "test-token",
+      publicKey: "test-key",
+      applicationId: "test-app-id",
+    });
+
+    const [options, durationMs, signal, url] =
+      mockStartGatewayListener.mock.calls[0];
+    expect(typeof options.waitUntil).toBe("function");
+    expect(durationMs).toBeUndefined();
+    expect(signal).toBeInstanceOf(AbortSignal);
+    expect(url).toBe("http://localhost:3000/api/webhooks/discord");
+  });
+
+  it("passes undefined webhookUrl when not provided", async () => {
+    const gw = new DiscordGateway();
+    await gw.start();
+
+    expect(mockStartGatewayListener.mock.calls[0][3]).toBeUndefined();
+  });
+});
+
+describe("DiscordGateway - stop and errors", () => {
+  beforeEach(resetMocks);
+
+  it("stops gateway and logs message", async () => {
+    const gw = new DiscordGateway();
+    await gw.start();
+    gw.stop();
+
+    expect(mockLog.info).toHaveBeenCalledWith("Gateway listener stopped");
+  });
+
+  it("does nothing when not started", () => {
+    new DiscordGateway().stop();
+    expect(mockLog.info).not.toHaveBeenCalledWith("Gateway listener stopped");
+  });
+
+  it("logs error when waitUntil task fails", async () => {
+    const gw = new DiscordGateway();
+    await gw.start();
+
+    const { waitUntil } = mockStartGatewayListener.mock.calls[0][0];
+    waitUntil(Promise.reject(new Error("bg fail")));
+
+    await new Promise((r) => setTimeout(r, 10));
+
+    expect(mockLog.error).toHaveBeenCalledWith(
+      { err: "Error: bg fail" },
+      "Gateway background task error",
+    );
+  });
+});

--- a/src/server/gateway/discord.gateway.ts
+++ b/src/server/gateway/discord.gateway.ts
@@ -1,0 +1,53 @@
+import { createDiscordAdapter } from "@chat-adapter/discord";
+import { env } from "@/app/config/env";
+import { getLogger } from "@/shared/utils/logger";
+
+export class DiscordGateway {
+  private abortController: AbortController | null = null;
+
+  async start(webhookUrl?: string): Promise<void> {
+    const { DISCORD_BOT_TOKEN, DISCORD_PUBLIC_KEY, DISCORD_APPLICATION_ID } =
+      env;
+
+    if (!(DISCORD_BOT_TOKEN && DISCORD_PUBLIC_KEY && DISCORD_APPLICATION_ID)) {
+      throw new Error(
+        "Gateway requires DISCORD_BOT_TOKEN, DISCORD_PUBLIC_KEY, and DISCORD_APPLICATION_ID",
+      );
+    }
+
+    const log = getLogger();
+    const adapter = createDiscordAdapter({
+      botToken: DISCORD_BOT_TOKEN,
+      publicKey: DISCORD_PUBLIC_KEY,
+      applicationId: DISCORD_APPLICATION_ID,
+    });
+
+    this.abortController = new AbortController();
+
+    log.info(
+      { webhookUrl: webhookUrl ?? "not configured" },
+      "Starting Gateway listener",
+    );
+
+    await adapter.startGatewayListener(
+      {
+        waitUntil: (task) => {
+          task.catch((err) => {
+            log.error({ err: String(err) }, "Gateway background task error");
+          });
+        },
+      },
+      undefined,
+      this.abortController.signal,
+      webhookUrl,
+    );
+  }
+
+  stop(): void {
+    if (this.abortController) {
+      this.abortController.abort();
+      this.abortController = null;
+      getLogger().info("Gateway listener stopped");
+    }
+  }
+}

--- a/src/server/hono.test.ts
+++ b/src/server/hono.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@/shared/utils/logger", () => ({
-  getLogger: vi.fn().mockReturnValue({ info: vi.fn() }),
+  getLogger: vi.fn().mockReturnValue({ info: vi.fn(), warn: vi.fn() }),
 }));
 
 describe("createApp without deps", () => {
@@ -44,6 +44,17 @@ describe("createApp without deps", () => {
     const res = await app.request("/api/webhooks/discord", { method: "POST" });
 
     expect(res.status).toBe(404);
+  });
+
+  it("logs warning when called without deps", async () => {
+    const { getLogger } = await import("@/shared/utils/logger");
+    const { createApp } = await import("@/server/hono");
+
+    createApp();
+
+    expect(getLogger().warn).toHaveBeenCalledWith(
+      "createApp called without deps — Discord webhook route not mounted",
+    );
   });
 });
 

--- a/src/server/hono.test.ts
+++ b/src/server/hono.test.ts
@@ -4,7 +4,7 @@ vi.mock("@/shared/utils/logger", () => ({
   getLogger: vi.fn().mockReturnValue({ info: vi.fn() }),
 }));
 
-describe("createApp", () => {
+describe("createApp without deps", () => {
   beforeEach(() => {
     vi.resetModules();
     vi.restoreAllMocks();
@@ -35,5 +35,52 @@ describe("createApp", () => {
     const res = await app.request("/nonexistent");
 
     expect(res.status).toBe(404);
+  });
+
+  it("does not mount discord route when no deps provided", async () => {
+    const { createApp } = await import("@/server/hono");
+
+    const app = createApp();
+    const res = await app.request("/api/webhooks/discord", { method: "POST" });
+
+    expect(res.status).toBe(404);
+  });
+});
+
+describe("createApp with deps", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.restoreAllMocks();
+  });
+
+  it("mounts discord route when deps are provided", async () => {
+    vi.doMock("@/server/middleware/verify-discord", () => ({
+      verifyDiscord: async (_c: unknown, next: () => Promise<void>) => {
+        await next();
+      },
+    }));
+    vi.doMock("@/sdk/discord/adapter/interaction.adapter", () => ({
+      toDomain: () => ({
+        ok: true,
+        value: { id: "1", type: "ping", channelId: "", userId: "" },
+      }),
+    }));
+    vi.doMock("@/sdk/discord/adapter/response.adapter", () => ({
+      toDiscord: (r: unknown) => r,
+    }));
+
+    const { createApp } = await import("@/server/hono");
+    const mockHandler = {
+      handle: vi.fn().mockResolvedValue({ type: 1 }),
+    };
+
+    const app = createApp({ interactionHandler: mockHandler as never });
+    const res = await app.request("/api/webhooks/discord", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ type: 1 }),
+    });
+
+    expect(res.status).toBe(200);
   });
 });

--- a/src/server/hono.ts
+++ b/src/server/hono.ts
@@ -1,13 +1,20 @@
 import { Hono } from "hono";
+import type { InteractionHandler } from "@/bot/handlers/interaction.handler";
 import { logger } from "@/server/middleware/logger";
+import { createDiscordRoute } from "@/server/routes/discord.route";
 import { health } from "@/server/routes/health.route";
 
-export function createApp() {
+export function createApp(deps?: { interactionHandler: InteractionHandler }) {
   const app = new Hono();
 
   app.use("*", logger);
 
   app.route("/health", health);
+
+  if (deps) {
+    const discord = createDiscordRoute(deps);
+    app.route("/api/webhooks/discord", discord);
+  }
 
   return app;
 }

--- a/src/server/hono.ts
+++ b/src/server/hono.ts
@@ -3,6 +3,7 @@ import type { InteractionHandler } from "@/bot/handlers/interaction.handler";
 import { logger } from "@/server/middleware/logger";
 import { createDiscordRoute } from "@/server/routes/discord.route";
 import { health } from "@/server/routes/health.route";
+import { getLogger } from "@/shared/utils/logger";
 
 export function createApp(deps?: { interactionHandler: InteractionHandler }) {
   const app = new Hono();
@@ -14,6 +15,10 @@ export function createApp(deps?: { interactionHandler: InteractionHandler }) {
   if (deps) {
     const discord = createDiscordRoute(deps);
     app.route("/api/webhooks/discord", discord);
+  } else {
+    getLogger().warn(
+      "createApp called without deps — Discord webhook route not mounted",
+    );
   }
 
   return app;

--- a/src/server/middleware/verify-discord.test.ts
+++ b/src/server/middleware/verify-discord.test.ts
@@ -1,0 +1,163 @@
+import type { Context, Next } from "hono";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockLog = {
+  error: vi.fn(),
+  warn: vi.fn(),
+  debug: vi.fn(),
+  info: vi.fn(),
+};
+
+const mockEnv: { DISCORD_PUBLIC_KEY: string | undefined } = {
+  DISCORD_PUBLIC_KEY: "test-public-key",
+};
+
+vi.mock("@/shared/utils/logger", () => ({ getLogger: () => mockLog }));
+
+vi.mock("@/app/config/env", () => ({
+  get env() {
+    return mockEnv;
+  },
+}));
+
+const mockVerifyAsync = vi.fn();
+
+vi.mock("@noble/ed25519", () => ({
+  etc: { hexToBytes: (hex: string) => new TextEncoder().encode(hex) },
+  verifyAsync: (...args: unknown[]) => mockVerifyAsync(...args),
+}));
+
+const { verifyDiscord } = await import("@/server/middleware/verify-discord");
+
+function createContext(headers: Record<string, string> = {}, body = "") {
+  const raw = new Request("https://example.com", {
+    method: "POST",
+    headers,
+    body,
+  });
+  const set = vi.fn();
+  const next = vi.fn().mockResolvedValue(undefined) as unknown as Next;
+  const c = {
+    req: { header: (name: string) => headers[name] ?? null, raw },
+    set,
+    json: vi.fn().mockReturnValue({}),
+    res: { status: 200 },
+  } as unknown as Context;
+  return { c, set, next };
+}
+
+describe("verifyDiscord - config and header errors", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    mockLog.error.mockReset();
+    mockLog.warn.mockReset();
+    mockEnv.DISCORD_PUBLIC_KEY = "test-public-key";
+  });
+
+  it("returns 401 when DISCORD_PUBLIC_KEY is not configured", async () => {
+    mockEnv.DISCORD_PUBLIC_KEY = undefined;
+    const { c, next } = createContext();
+
+    await verifyDiscord(c, next);
+
+    expect(c.json).toHaveBeenCalledWith(
+      { error: "Server configuration error" },
+      401,
+    );
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it("returns 401 when x-signature-ed25519 header is missing", async () => {
+    const { c, next } = createContext({ "x-signature-timestamp": "ts" });
+
+    await verifyDiscord(c, next);
+
+    expect(c.json).toHaveBeenCalledWith(
+      { error: "Missing signature headers" },
+      401,
+    );
+  });
+
+  it("returns 401 when x-signature-timestamp header is missing", async () => {
+    const { c, next } = createContext({ "x-signature-ed25519": "sig" });
+
+    await verifyDiscord(c, next);
+
+    expect(c.json).toHaveBeenCalledWith(
+      { error: "Missing signature headers" },
+      401,
+    );
+  });
+});
+
+describe("verifyDiscord - signature rejection", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    mockLog.warn.mockReset();
+    mockLog.error.mockReset();
+    mockVerifyAsync.mockReset();
+    mockEnv.DISCORD_PUBLIC_KEY = "test-public-key";
+  });
+
+  it("returns 401 when signature is invalid", async () => {
+    mockVerifyAsync.mockResolvedValue(false);
+    const { c, next } = createContext(
+      { "x-signature-ed25519": "badsig", "x-signature-timestamp": "ts" },
+      '{"type":1}',
+    );
+
+    await verifyDiscord(c, next);
+
+    expect(c.json).toHaveBeenCalledWith({ error: "Invalid signature" }, 401);
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it("returns 401 when verifyAsync throws", async () => {
+    mockVerifyAsync.mockRejectedValue(new Error("bad key"));
+    const { c, next } = createContext(
+      { "x-signature-ed25519": "sig", "x-signature-timestamp": "ts" },
+      '{"type":1}',
+    );
+
+    await verifyDiscord(c, next);
+
+    expect(c.json).toHaveBeenCalledWith({ error: "Invalid signature" }, 401);
+  });
+});
+
+describe("verifyDiscord - signature success", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    mockLog.debug.mockReset();
+    mockVerifyAsync.mockReset();
+    mockEnv.DISCORD_PUBLIC_KEY = "test-public-key";
+  });
+
+  it("calls next when signature is valid", async () => {
+    mockVerifyAsync.mockResolvedValue(true);
+    const { c, next } = createContext(
+      { "x-signature-ed25519": "validsig", "x-signature-timestamp": "ts" },
+      '{"type":1}',
+    );
+
+    await verifyDiscord(c, next);
+
+    expect(next).toHaveBeenCalledOnce();
+    expect(mockLog.debug).toHaveBeenCalledWith(
+      "Discord signature verification passed",
+    );
+  });
+
+  it("preserves request body for downstream handler", async () => {
+    mockVerifyAsync.mockResolvedValue(true);
+    const body = '{"type":1,"id":"test"}';
+    const { c, next } = createContext(
+      { "x-signature-ed25519": "validsig", "x-signature-timestamp": "ts" },
+      body,
+    );
+
+    await verifyDiscord(c, next);
+
+    expect(await c.req.raw.text()).toBe(body);
+  });
+});

--- a/src/server/middleware/verify-discord.ts
+++ b/src/server/middleware/verify-discord.ts
@@ -1,0 +1,49 @@
+import { etc, verifyAsync } from "@noble/ed25519";
+import type { MiddlewareHandler } from "hono";
+import { env } from "@/app/config/env";
+import { HTTP_UNAUTHORIZED } from "@/shared/utils/http-status";
+import { getLogger } from "@/shared/utils/logger";
+
+export const verifyDiscord: MiddlewareHandler = async (c, next) => {
+  const log = getLogger();
+  const publicKey = env.DISCORD_PUBLIC_KEY;
+
+  if (!publicKey) {
+    log.error("DISCORD_PUBLIC_KEY is not configured");
+    return c.json({ error: "Server configuration error" }, HTTP_UNAUTHORIZED);
+  }
+
+  const signature = c.req.header("x-signature-ed25519");
+  const timestamp = c.req.header("x-signature-timestamp");
+
+  if (!(signature && timestamp)) {
+    log.warn(
+      { hasSignature: Boolean(signature), hasTimestamp: Boolean(timestamp) },
+      "Missing signature headers",
+    );
+    return c.json({ error: "Missing signature headers" }, HTTP_UNAUTHORIZED);
+  }
+
+  const body = await c.req.raw.clone().text();
+  const message = new TextEncoder().encode(timestamp + body);
+
+  let isValid: boolean;
+  try {
+    isValid = await verifyAsync(
+      etc.hexToBytes(signature),
+      message,
+      etc.hexToBytes(publicKey),
+    );
+  } catch {
+    log.error("Signature verification error");
+    return c.json({ error: "Invalid signature" }, HTTP_UNAUTHORIZED);
+  }
+
+  if (!isValid) {
+    log.warn("Discord signature verification failed");
+    return c.json({ error: "Invalid signature" }, HTTP_UNAUTHORIZED);
+  }
+
+  log.debug("Discord signature verification passed");
+  await next();
+};

--- a/src/server/routes/discord.route.test.ts
+++ b/src/server/routes/discord.route.test.ts
@@ -1,0 +1,167 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { InteractionHandler } from "@/bot/handlers/interaction.handler";
+import type { DomainInteraction } from "@/sdk/discord/types/domain";
+
+const mockLog = {
+  warn: vi.fn(),
+  error: vi.fn(),
+  info: vi.fn(),
+  debug: vi.fn(),
+};
+
+vi.mock("@/shared/utils/logger", () => ({ getLogger: () => mockLog }));
+
+vi.mock("@/server/middleware/verify-discord", () => ({
+  verifyDiscord: async (_c: unknown, next: () => Promise<void>) => {
+    await next();
+  },
+}));
+
+const mockToDomain = vi.fn();
+vi.mock("@/sdk/discord/adapter/interaction.adapter", () => ({
+  toDomain: (...args: unknown[]) => mockToDomain(...args),
+}));
+
+const mockToDiscord = vi.fn();
+vi.mock("@/sdk/discord/adapter/response.adapter", () => ({
+  toDiscord: (...args: unknown[]) => mockToDiscord(...args),
+}));
+
+const { createDiscordRoute } = await import("@/server/routes/discord.route");
+
+function createMockHandler() {
+  return { handle: vi.fn() } as unknown as InteractionHandler;
+}
+
+describe("createDiscordRoute - error cases", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    mockLog.warn.mockReset();
+    mockLog.error.mockReset();
+    mockToDomain.mockReset();
+    mockToDiscord.mockReset();
+  });
+
+  it("returns 400 when toDomain returns error", async () => {
+    mockToDomain.mockReturnValue({
+      ok: false,
+      error: new Error("missing interaction id"),
+    });
+    const app = createDiscordRoute({ interactionHandler: createMockHandler() });
+
+    const res = await app.request("/", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({}),
+    });
+
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: "missing interaction id" });
+  });
+
+  it("returns 500 when handler throws", async () => {
+    const handler = createMockHandler();
+    mockToDomain.mockReturnValue({
+      ok: true,
+      value: {
+        id: "3",
+        type: "command",
+        channelId: "",
+        userId: "",
+        commandName: "fail",
+        raw: {},
+      },
+    });
+    vi.mocked(handler).handle = vi.fn().mockRejectedValue(new Error("boom"));
+    const app = createDiscordRoute({ interactionHandler: handler });
+
+    const res = await app.request("/", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ type: 2, id: "3" }),
+    });
+
+    expect(res.status).toBe(500);
+    expect(await res.json()).toEqual({ error: "Internal error" });
+  });
+});
+
+describe("createDiscordRoute - invalid body", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    mockToDomain.mockReset();
+    mockToDiscord.mockReset();
+  });
+
+  it("returns 500 when body is not valid JSON", async () => {
+    const handler = createMockHandler();
+    const app = createDiscordRoute({ interactionHandler: handler });
+
+    const res = await app.request("/", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: "not-json",
+    });
+
+    expect(res.status).toBe(500);
+  });
+});
+
+describe("createDiscordRoute - success cases", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    mockToDomain.mockReset();
+    mockToDiscord.mockReset();
+  });
+
+  it("returns 200 with pong for ping interaction", async () => {
+    const handler = createMockHandler();
+    const interaction: DomainInteraction = {
+      id: "1",
+      type: "ping",
+      channelId: "",
+      userId: "",
+      raw: {},
+    };
+    mockToDomain.mockReturnValue({ ok: true, value: interaction });
+    vi.mocked(handler).handle = vi.fn().mockResolvedValue({ type: 1 });
+    mockToDiscord.mockReturnValue({ type: 1 });
+    const app = createDiscordRoute({ interactionHandler: handler });
+
+    const res = await app.request("/", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ type: 1, id: "1" }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(handler.handle).toHaveBeenCalledWith(interaction);
+    expect(mockToDiscord).toHaveBeenCalledWith({ type: 1 });
+  });
+
+  it("returns 200 with command response", async () => {
+    const handler = createMockHandler();
+    const interaction: DomainInteraction = {
+      id: "2",
+      type: "command",
+      channelId: "ch1",
+      userId: "u1",
+      commandName: "ping",
+      raw: {},
+    };
+    const domainResponse = { type: 4, data: { content: "Pong!" } };
+    mockToDomain.mockReturnValue({ ok: true, value: interaction });
+    vi.mocked(handler).handle = vi.fn().mockResolvedValue(domainResponse);
+    mockToDiscord.mockReturnValue({ type: 4, data: { content: "Pong!" } });
+    const app = createDiscordRoute({ interactionHandler: handler });
+
+    const res = await app.request("/", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ type: 2, id: "2", data: { name: "ping" } }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ type: 4, data: { content: "Pong!" } });
+  });
+});

--- a/src/server/routes/discord.route.ts
+++ b/src/server/routes/discord.route.ts
@@ -1,0 +1,40 @@
+import { Hono } from "hono";
+import type { InteractionHandler } from "@/bot/handlers/interaction.handler";
+import { toDomain } from "@/sdk/discord/adapter/interaction.adapter";
+import { toDiscord } from "@/sdk/discord/adapter/response.adapter";
+import { verifyDiscord } from "@/server/middleware/verify-discord";
+import {
+  HTTP_BAD_REQUEST,
+  HTTP_INTERNAL_SERVER_ERROR,
+  HTTP_OK,
+} from "@/shared/utils/http-status";
+import { getLogger } from "@/shared/utils/logger";
+
+export function createDiscordRoute(deps: {
+  interactionHandler: InteractionHandler;
+}): Hono {
+  const discord = new Hono();
+  const log = getLogger();
+
+  discord.use("*", verifyDiscord);
+
+  discord.post("/", async (c) => {
+    const raw = await c.req.json();
+    const result = toDomain(raw);
+
+    if (!result.ok) {
+      log.warn({ error: result.error.message }, "Invalid interaction payload");
+      return c.json({ error: result.error.message }, HTTP_BAD_REQUEST);
+    }
+
+    try {
+      const response = await deps.interactionHandler.handle(result.value);
+      return c.json(toDiscord(response), HTTP_OK);
+    } catch {
+      log.error("Interaction handler error");
+      return c.json({ error: "Internal error" }, HTTP_INTERNAL_SERVER_ERROR);
+    }
+  });
+
+  return discord;
+}


### PR DESCRIPTION
# チケット

close #13

# 概要

Issue #13 の実装として、`server/` 層のHonoサーバー・ミドルウェア・Gateway関連のコンポーネントを追加しました。

### 追加・変更内容

- **環境変数の拡張** — `OPENAI_API_KEY`, `DISCORD_PUBLIC_KEY`, `DISCORD_BOT_TOKEN`, `DISCORD_APPLICATION_ID` をenvスキーマに追加
- **Discord署名検証ミドルウェア** — Ed25519署名によるDiscordリクエスト検証 (`verify-discord.ts`)
- **Discord Webhookルート** — `POST /api/webhooks/discord` エンドポイント (`discord.route.ts`)
- **Discord Gateway** — WebSocket経由のメッセージイベント転送 (`discord.gateway.ts`)
- **createAppの依存関係注入** — `interactionHandler` を受け取り、ルートをマウントするよう変更 (`hono.ts`)
- **Bootstrapの更新** — Redis, AIサービス, コマンドルーター, InteractionHandler, Gatewayを初期化・注入
- **シャットダウンハンドラー** — SIGTERM/SIGINTでGateway・サーバーを安全に終了

### 依存の流れ

```
verify-discord (署名検証)
 ↓
logger (リクエストログ)
 ↓
discord.route → InteractionHandler.handle(interaction)
 ↓
Discord Response (JSON)
```

# その他

resolves #13