### PR TITLE
✨ shutdown関数をbootstrapに集約しRedis切断処理を追加

### DIFF
--- a/src/app/bootstrap.test.ts
+++ b/src/app/bootstrap.test.ts
@@ -16,6 +16,9 @@ vi.mock("@/shared/utils/logger", () => ({
 
 const mockCreateApp = vi.fn().mockReturnValue({ fetch: vi.fn() });
 const mockStart = vi.fn().mockResolvedValue(undefined);
+const mockStop = vi.fn();
+const mockRedisDisconnect = vi.fn().mockResolvedValue(undefined);
+const mockRedisConnect = vi.fn().mockResolvedValue(undefined);
 
 function setupMocks(
   config: Record<string, unknown>,
@@ -40,13 +43,16 @@ function setupMocks(
   vi.doMock("@/server/gateway/discord.gateway", () => ({
     // biome-ignore lint/complexity/useArrowFunction: constructor mock requires function
     DiscordGateway: vi.fn().mockImplementation(function () {
-      return { start: mockStart, stop: vi.fn() };
+      return { start: mockStart, stop: mockStop };
     }),
   }));
   vi.doMock("@/infrastructure/redis/redis.client", () => ({
     // biome-ignore lint/complexity/useArrowFunction: constructor mock requires function
     RedisClient: vi.fn().mockImplementation(function () {
-      return { connect: vi.fn().mockResolvedValue(undefined) };
+      return {
+        connect: mockRedisConnect,
+        disconnect: mockRedisDisconnect,
+      };
     }),
   }));
   vi.doMock("@/ai/client/codex.client", () => ({
@@ -97,15 +103,17 @@ describe("bootstrap result", () => {
   });
 });
 
-describe("bootstrap gateway", () => {
+describe("bootstrap shutdown", () => {
   beforeEach(() => {
     vi.resetModules();
     vi.restoreAllMocks();
     mockCreateApp.mockClear();
     mockCreateApp.mockReturnValue({ fetch: vi.fn() });
+    mockRedisDisconnect.mockClear();
+    mockStop.mockClear();
   });
 
-  it("returns null gateway when DISCORD_BOT_TOKEN is not set", async () => {
+  it("returns shutdown function", async () => {
     setupMocks({
       bot: { defaultModel: "codex-mini", maxTokens: 4096, timeoutMs: 30000 },
       server: { port: 3000 },
@@ -116,10 +124,10 @@ describe("bootstrap gateway", () => {
 
     const result = bootstrap();
 
-    expect(result.gateway).toBeNull();
+    expect(typeof result.shutdown).toBe("function");
   });
 
-  it("returns gateway when DISCORD_BOT_TOKEN is set", async () => {
+  it("shutdown disconnects Redis and stops Gateway", async () => {
     setupMocks(
       {
         bot: { defaultModel: "codex-mini", maxTokens: 4096, timeoutMs: 30000 },
@@ -132,10 +140,26 @@ describe("bootstrap gateway", () => {
     const { bootstrap } = await import("@/app/bootstrap");
 
     const result = bootstrap();
+    await result.shutdown();
 
-    expect(result.gateway).not.toBeNull();
-    expect(result.gateway).toHaveProperty("start");
-    expect(result.gateway).toHaveProperty("stop");
+    expect(mockRedisDisconnect).toHaveBeenCalled();
+    expect(mockStop).toHaveBeenCalled();
+  });
+
+  it("shutdown works without Gateway", async () => {
+    setupMocks({
+      bot: { defaultModel: "codex-mini", maxTokens: 4096, timeoutMs: 30000 },
+      server: { port: 3000 },
+      logging: { level: "info" },
+    });
+
+    const { bootstrap } = await import("@/app/bootstrap");
+
+    const result = bootstrap();
+    await result.shutdown();
+
+    expect(mockRedisDisconnect).toHaveBeenCalled();
+    expect(mockStop).not.toHaveBeenCalled();
   });
 });
 

--- a/src/app/bootstrap.ts
+++ b/src/app/bootstrap.ts
@@ -48,5 +48,11 @@ export function bootstrap() {
 
   log.info({ port: config.server.port }, "Bootstrap completed");
 
-  return { app, port: config.server.port, gateway };
+  const shutdown = async () => {
+    log.info("Shutting down");
+    await redis.disconnect();
+    gateway?.stop();
+  };
+
+  return { app, port: config.server.port, shutdown };
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,19 +2,18 @@ import { serve } from "@hono/node-server";
 import { bootstrap } from "@/app/bootstrap";
 import { getLogger } from "@/shared/utils/logger";
 
-const { app, port, gateway } = bootstrap();
+const { app, port, shutdown } = bootstrap();
 
 const server = serve({ fetch: app.fetch, port }, (info) => {
   getLogger().info({ port: info.port }, "Server running");
 });
 
-function shutdown() {
-  getLogger().info("Shutting down");
-  gateway?.stop();
+async function handleShutdown() {
+  await shutdown();
   server.close(() => {
     process.exit(0);
   });
 }
 
-process.on("SIGTERM", shutdown);
-process.on("SIGINT", shutdown);
+process.on("SIGTERM", handleShutdown);
+process.on("SIGINT", handleShutdown);


### PR DESCRIPTION
# チケット

close #14

# 概要

これまでシャットダウン処理（Gatewayの停止）は `src/index.ts` に直接記述されていましたが、今回の変更でRedisの切断処理も含めて `bootstrap()` に集約しました。

### 変更内容

- **`src/app/bootstrap.ts`**: `shutdown` 関数を追加し、Redis切断とGateway停止を一元管理。戻り値を `gateway` から `shutdown` に変更。
- **`src/index.ts`**: bootstrapから `shutdown` を受け取り、SIGTERM/SIGINT時に呼び出すよう更新。ローカル関数を `handleShutdown` にリネーム。
- **`src/app/bootstrap.test.ts`**: shutdown関数のテストを追加（Redis切断とGateway停止の検証、Gatewayなしでの動作確認）。

# その他

resolves #14