### PR TITLE
Gatewayイベント経由でメンションメッセージを処理する機能を追加

### DIFF
--- a/src/app/bootstrap.test.ts
+++ b/src/app/bootstrap.test.ts
@@ -32,8 +32,8 @@ function setupMocks(
       NODE_ENV: "test",
       OPENAI_API_KEY: "test-key",
       DISCORD_PUBLIC_KEY: "test-pk",
-      DISCORD_BOT_TOKEN: undefined,
-      DISCORD_APPLICATION_ID: undefined,
+      DISCORD_BOT_TOKEN: "test-bot-token",
+      DISCORD_APPLICATION_ID: "test-app-id",
       ...envOverrides,
     },
   }));
@@ -128,25 +128,6 @@ describe("bootstrap shutdown", () => {
   });
 
   it("shutdown disconnects Redis and stops Gateway", async () => {
-    setupMocks(
-      {
-        bot: { defaultModel: "codex-mini", maxTokens: 4096, timeoutMs: 30000 },
-        server: { port: 3000 },
-        logging: { level: "info" },
-      },
-      { DISCORD_BOT_TOKEN: "test-bot-token" },
-    );
-
-    const { bootstrap } = await import("@/app/bootstrap");
-
-    const result = bootstrap();
-    await result.shutdown();
-
-    expect(mockRedisDisconnect).toHaveBeenCalled();
-    expect(mockStop).toHaveBeenCalled();
-  });
-
-  it("shutdown works without Gateway", async () => {
     setupMocks({
       bot: { defaultModel: "codex-mini", maxTokens: 4096, timeoutMs: 30000 },
       server: { port: 3000 },
@@ -159,7 +140,23 @@ describe("bootstrap shutdown", () => {
     await result.shutdown();
 
     expect(mockRedisDisconnect).toHaveBeenCalled();
-    expect(mockStop).not.toHaveBeenCalled();
+    expect(mockStop).toHaveBeenCalled();
+  });
+
+  it("shutdown always stops Gateway", async () => {
+    setupMocks({
+      bot: { defaultModel: "codex-mini", maxTokens: 4096, timeoutMs: 30000 },
+      server: { port: 3000 },
+      logging: { level: "info" },
+    });
+
+    const { bootstrap } = await import("@/app/bootstrap");
+
+    const result = bootstrap();
+    await result.shutdown();
+
+    expect(mockRedisDisconnect).toHaveBeenCalled();
+    expect(mockStop).toHaveBeenCalled();
   });
 });
 

--- a/src/app/bootstrap.ts
+++ b/src/app/bootstrap.ts
@@ -13,6 +13,24 @@ import { DiscordGateway } from "@/server/gateway/discord.gateway";
 import { createApp } from "@/server/hono";
 import { createLogger, getLogger } from "@/shared/utils/logger";
 
+function initDiscord(aiService: AIService) {
+  const botToken = env.DISCORD_BOT_TOKEN;
+  const applicationId = env.DISCORD_APPLICATION_ID;
+  if (!botToken) {
+    throw new Error("DISCORD_BOT_TOKEN is required");
+  }
+  if (!applicationId) {
+    throw new Error("DISCORD_APPLICATION_ID is required");
+  }
+  const discordApiClient = new DiscordApiClient(botToken);
+  const messageHandler = new MessageHandler(
+    aiService,
+    discordApiClient,
+    applicationId,
+  );
+  return { botToken, applicationId, discordApiClient, messageHandler };
+}
+
 export function bootstrap() {
   const config = loadConfig();
 
@@ -37,32 +55,22 @@ export function bootstrap() {
   const router = new Router(commands);
   const interactionHandler = new InteractionHandler(router);
 
-  const botToken = env.DISCORD_BOT_TOKEN ?? "";
-  const applicationId = env.DISCORD_APPLICATION_ID ?? "";
-  const discordApiClient = new DiscordApiClient(botToken);
-  const messageHandler = new MessageHandler(
-    aiService,
-    discordApiClient,
-    applicationId,
-  );
+  const { botToken, messageHandler } = initDiscord(aiService);
 
   const app = createApp({ interactionHandler, messageHandler, botToken });
 
-  let gateway: DiscordGateway | null = null;
-  if (env.DISCORD_BOT_TOKEN) {
-    gateway = new DiscordGateway();
-    const webhookUrl = `http://localhost:${config.server.port}/api/webhooks/discord`;
-    gateway.start(webhookUrl).catch((err) => {
-      log.error({ err: String(err) }, "Gateway startup failed");
-    });
-  }
+  const gateway = new DiscordGateway();
+  const webhookUrl = `http://localhost:${config.server.port}/api/webhooks/discord`;
+  gateway.start(webhookUrl).catch((err) => {
+    log.error({ err: String(err) }, "Gateway startup failed");
+  });
 
   log.info({ port: config.server.port }, "Bootstrap completed");
 
   const shutdown = async () => {
     log.info("Shutting down");
     await redis.disconnect();
-    gateway?.stop();
+    gateway.stop();
   };
 
   return { app, port: config.server.port, shutdown };

--- a/src/app/bootstrap.ts
+++ b/src/app/bootstrap.ts
@@ -5,7 +5,9 @@ import { env } from "@/app/config/env";
 import { ChatCommand } from "@/bot/commands/ai/chat.command";
 import { PingCommand } from "@/bot/commands/utility/ping.command";
 import { InteractionHandler } from "@/bot/handlers/interaction.handler";
+import { MessageHandler } from "@/bot/handlers/message.handler";
 import { Router } from "@/bot/router";
+import { DiscordApiClient } from "@/infrastructure/discord/discord-api.client";
 import { RedisClient } from "@/infrastructure/redis/redis.client";
 import { DiscordGateway } from "@/server/gateway/discord.gateway";
 import { createApp } from "@/server/hono";
@@ -35,7 +37,16 @@ export function bootstrap() {
   const router = new Router(commands);
   const interactionHandler = new InteractionHandler(router);
 
-  const app = createApp({ interactionHandler });
+  const botToken = env.DISCORD_BOT_TOKEN ?? "";
+  const applicationId = env.DISCORD_APPLICATION_ID ?? "";
+  const discordApiClient = new DiscordApiClient(botToken);
+  const messageHandler = new MessageHandler(
+    aiService,
+    discordApiClient,
+    applicationId,
+  );
+
+  const app = createApp({ interactionHandler, messageHandler, botToken });
 
   let gateway: DiscordGateway | null = null;
   if (env.DISCORD_BOT_TOKEN) {

--- a/src/bot/handlers/message.handler.test.ts
+++ b/src/bot/handlers/message.handler.test.ts
@@ -1,0 +1,193 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { AIService } from "@/ai/services/ai.service";
+import type { DiscordApiClient } from "@/infrastructure/discord/discord-api.client";
+import type { GatewayEvent } from "@/sdk/discord/types/gateway";
+
+const mockLogInfo = vi.fn();
+const mockLogError = vi.fn();
+const mockLogWarn = vi.fn();
+const mockLogDebug = vi.fn();
+
+vi.mock("@/shared/utils/logger", () => ({
+  getLogger: vi.fn().mockReturnValue({
+    info: mockLogInfo,
+    error: mockLogError,
+    warn: mockLogWarn,
+    debug: mockLogDebug,
+  }),
+}));
+
+const mockChat = vi.fn();
+const mockSendMessage = vi.fn();
+
+vi.mock("@/ai/services/ai.service", () => ({
+  AIService: vi.fn().mockImplementation(() => ({ chat: mockChat })),
+}));
+
+vi.mock("@/infrastructure/discord/discord-api.client", () => ({
+  DiscordApiClient: vi.fn().mockImplementation(() => ({
+    sendMessage: mockSendMessage,
+  })),
+}));
+
+const { MessageHandler } = await import("./message.handler");
+
+function makeMentionEvent(
+  overrides: Record<string, unknown> = {},
+): GatewayEvent {
+  return {
+    type: "GATEWAY_MESSAGE_CREATE",
+    timestamp: Date.now(),
+    data: {
+      id: "msg-1",
+      channel_id: "ch-1",
+      content: "<@app-id> hello",
+      author: { id: "user-1", username: "testuser" },
+      mentions: [{ id: "app-id", username: "testbot" }],
+      ...overrides,
+    },
+  };
+}
+
+describe("MessageHandler handleGatewayEvent - success", () => {
+  let handler: InstanceType<typeof MessageHandler>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    const aiService = { chat: mockChat } as unknown as AIService;
+    const discordApiClient = {
+      sendMessage: mockSendMessage,
+    } as unknown as DiscordApiClient;
+    handler = new MessageHandler(aiService, discordApiClient, "app-id");
+  });
+
+  it("processes @mention message and sends AI response", async () => {
+    mockChat.mockResolvedValue({ ok: true, value: "AI response here" });
+
+    await handler.handleGatewayEvent(makeMentionEvent());
+
+    expect(mockChat).toHaveBeenCalledWith("ch-1", "hello");
+    expect(mockSendMessage).toHaveBeenCalledWith("ch-1", "AI response here");
+  });
+
+  it("strips nickname format mention from content", async () => {
+    mockChat.mockResolvedValue({ ok: true, value: "response" });
+
+    const event = makeMentionEvent({
+      content: "<@!app-id> how are you?",
+    });
+
+    await handler.handleGatewayEvent(event);
+
+    expect(mockChat).toHaveBeenCalledWith("ch-1", "how are you?");
+  });
+});
+
+describe("MessageHandler handleGatewayEvent - filtering", () => {
+  let handler: InstanceType<typeof MessageHandler>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    const aiService = { chat: mockChat } as unknown as AIService;
+    const discordApiClient = {
+      sendMessage: mockSendMessage,
+    } as unknown as DiscordApiClient;
+    handler = new MessageHandler(aiService, discordApiClient, "app-id");
+  });
+
+  it("ignores non-mention events", async () => {
+    const event = makeMentionEvent();
+    (event.data as Record<string, unknown>).mentions = [];
+
+    await handler.handleGatewayEvent(event);
+
+    expect(mockChat).not.toHaveBeenCalled();
+    expect(mockSendMessage).not.toHaveBeenCalled();
+  });
+
+  it("ignores bot messages", async () => {
+    const event = makeMentionEvent();
+    (event.data as Record<string, unknown>).author = {
+      id: "bot-1",
+      username: "testbot",
+      bot: true,
+    };
+
+    await handler.handleGatewayEvent(event);
+
+    expect(mockChat).not.toHaveBeenCalled();
+  });
+
+  it("ignores non-MESSAGE_CREATE events", async () => {
+    const event: GatewayEvent = {
+      type: "GATEWAY_MESSAGE_REACTION_ADD",
+      timestamp: Date.now(),
+      data: {},
+    };
+
+    await handler.handleGatewayEvent(event);
+
+    expect(mockChat).not.toHaveBeenCalled();
+  });
+
+  it("ignores empty message after stripping mention", async () => {
+    const event = makeMentionEvent({
+      content: "<@app-id>",
+    });
+
+    await handler.handleGatewayEvent(event);
+
+    expect(mockChat).not.toHaveBeenCalled();
+    expect(mockLogDebug).toHaveBeenCalledWith(
+      { channelId: "ch-1" },
+      "Empty message after stripping mention",
+    );
+  });
+});
+
+describe("MessageHandler handleGatewayEvent - errors", () => {
+  let handler: InstanceType<typeof MessageHandler>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    const aiService = { chat: mockChat } as unknown as AIService;
+    const discordApiClient = {
+      sendMessage: mockSendMessage,
+    } as unknown as DiscordApiClient;
+    handler = new MessageHandler(aiService, discordApiClient, "app-id");
+  });
+
+  it("logs error when AIService fails", async () => {
+    mockChat.mockResolvedValue({
+      ok: false,
+      error: { message: "Codex error" },
+    });
+
+    await handler.handleGatewayEvent(makeMentionEvent());
+
+    expect(mockLogError).toHaveBeenCalledWith(
+      { error: "Codex error", channelId: "ch-1" },
+      "AI service error in mention handler",
+    );
+    expect(mockSendMessage).not.toHaveBeenCalled();
+  });
+
+  it("logs warning when message data extraction fails", async () => {
+    const event: GatewayEvent = {
+      type: "GATEWAY_MESSAGE_CREATE",
+      timestamp: Date.now(),
+      data: {
+        mentions: [{ id: "app-id", username: "testbot" }],
+        // missing required fields
+      },
+    };
+
+    await handler.handleGatewayEvent(event);
+
+    expect(mockLogWarn).toHaveBeenCalledWith(
+      { error: expect.any(String) },
+      "Failed to extract message data from gateway event",
+    );
+    expect(mockChat).not.toHaveBeenCalled();
+  });
+});

--- a/src/bot/handlers/message.handler.test.ts
+++ b/src/bot/handlers/message.handler.test.ts
@@ -172,6 +172,19 @@ describe("MessageHandler handleGatewayEvent - errors", () => {
     expect(mockSendMessage).not.toHaveBeenCalled();
   });
 
+  it("logs error when sendMessage returns false", async () => {
+    mockChat.mockResolvedValue({ ok: true, value: "AI response" });
+    mockSendMessage.mockResolvedValue(false);
+
+    await handler.handleGatewayEvent(makeMentionEvent());
+
+    expect(mockSendMessage).toHaveBeenCalledWith("ch-1", "AI response");
+    expect(mockLogError).toHaveBeenCalledWith(
+      { channelId: "ch-1" },
+      "Failed to send AI response to Discord",
+    );
+  });
+
   it("logs warning when message data extraction fails", async () => {
     const event: GatewayEvent = {
       type: "GATEWAY_MESSAGE_CREATE",

--- a/src/bot/handlers/message.handler.ts
+++ b/src/bot/handlers/message.handler.ts
@@ -56,6 +56,15 @@ export class MessageHandler {
       return;
     }
 
-    await this.discordApiClient.sendMessage(message.channel_id, result.value);
+    const sent = await this.discordApiClient.sendMessage(
+      message.channel_id,
+      result.value,
+    );
+    if (!sent) {
+      log.error(
+        { channelId: message.channel_id },
+        "Failed to send AI response to Discord",
+      );
+    }
   }
 }

--- a/src/bot/handlers/message.handler.ts
+++ b/src/bot/handlers/message.handler.ts
@@ -1,0 +1,61 @@
+import type { AIService } from "@/ai/services/ai.service";
+import type { DiscordApiClient } from "@/infrastructure/discord/discord-api.client";
+import {
+  extractMessageData,
+  isMentionEvent,
+  stripMentionFromContent,
+} from "@/sdk/discord/adapter/gateway-event.adapter";
+import type { GatewayEvent } from "@/sdk/discord/types/gateway";
+import { getLogger } from "@/shared/utils/logger";
+
+export class MessageHandler {
+  constructor(
+    private aiService: AIService,
+    private discordApiClient: DiscordApiClient,
+    private applicationId: string,
+  ) {}
+
+  async handleGatewayEvent(event: GatewayEvent): Promise<void> {
+    const log = getLogger();
+
+    if (!isMentionEvent(event, this.applicationId)) return;
+
+    const messageResult = extractMessageData(event);
+    if (!messageResult.ok) {
+      log.warn(
+        { error: messageResult.error.message },
+        "Failed to extract message data from gateway event",
+      );
+      return;
+    }
+
+    const message = messageResult.value;
+
+    if (message.author.bot) return;
+
+    const userMessage = stripMentionFromContent(
+      message.content,
+      this.applicationId,
+    );
+
+    if (!userMessage) {
+      log.debug(
+        { channelId: message.channel_id },
+        "Empty message after stripping mention",
+      );
+      return;
+    }
+
+    const result = await this.aiService.chat(message.channel_id, userMessage);
+
+    if (!result.ok) {
+      log.error(
+        { error: result.error.message, channelId: message.channel_id },
+        "AI service error in mention handler",
+      );
+      return;
+    }
+
+    await this.discordApiClient.sendMessage(message.channel_id, result.value);
+  }
+}

--- a/src/infrastructure/discord/discord-api.client.test.ts
+++ b/src/infrastructure/discord/discord-api.client.test.ts
@@ -1,0 +1,81 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockLogInfo = vi.fn();
+const mockLogError = vi.fn();
+
+vi.mock("@/shared/utils/logger", () => ({
+  getLogger: vi.fn().mockReturnValue({
+    info: mockLogInfo,
+    error: mockLogError,
+    warn: vi.fn(),
+    debug: vi.fn(),
+  }),
+}));
+
+const mockFetch = vi.fn();
+vi.stubGlobal("fetch", mockFetch);
+
+const { DiscordApiClient } = await import("./discord-api.client");
+
+describe("DiscordApiClient sendMessage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("sends message with correct URL and headers", async () => {
+    mockFetch.mockResolvedValue({ ok: true });
+    const client = new DiscordApiClient("test-token");
+
+    await client.sendMessage("ch-123", "Hello!");
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      "https://discord.com/api/v10/channels/ch-123/messages",
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: "Bot test-token",
+        },
+        body: JSON.stringify({ content: "Hello!" }),
+      },
+    );
+  });
+
+  it("does not throw on API error response", async () => {
+    mockFetch.mockResolvedValue({ ok: false, status: 403 });
+    const client = new DiscordApiClient("test-token");
+
+    await expect(
+      client.sendMessage("ch-123", "Hello!"),
+    ).resolves.toBeUndefined();
+    expect(mockLogError).toHaveBeenCalledWith(
+      { status: 403, channelId: "ch-123" },
+      "Failed to send Discord message",
+    );
+  });
+
+  it("does not throw on network error", async () => {
+    mockFetch.mockRejectedValue(new Error("ECONNREFUSED"));
+    const client = new DiscordApiClient("test-token");
+
+    await expect(
+      client.sendMessage("ch-123", "Hello!"),
+    ).resolves.toBeUndefined();
+    expect(mockLogError).toHaveBeenCalledWith(
+      { err: "ECONNREFUSED", channelId: "ch-123" },
+      "Discord API request failed",
+    );
+  });
+
+  it("logs error with status 429 for rate limiting", async () => {
+    mockFetch.mockResolvedValue({ ok: false, status: 429 });
+    const client = new DiscordApiClient("test-token");
+
+    await client.sendMessage("ch-123", "Hello!");
+
+    expect(mockLogError).toHaveBeenCalledWith(
+      { status: 429, channelId: "ch-123" },
+      "Failed to send Discord message",
+    );
+  });
+});

--- a/src/infrastructure/discord/discord-api.client.test.ts
+++ b/src/infrastructure/discord/discord-api.client.test.ts
@@ -17,9 +17,18 @@ vi.stubGlobal("fetch", mockFetch);
 
 const { DiscordApiClient } = await import("./discord-api.client");
 
-describe("DiscordApiClient sendMessage", () => {
+describe("DiscordApiClient sendMessage success", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+  });
+
+  it("returns true on success", async () => {
+    mockFetch.mockResolvedValue({ ok: true });
+    const client = new DiscordApiClient("test-token");
+
+    const result = await client.sendMessage("ch-123", "Hello!");
+
+    expect(result).toBe(true);
   });
 
   it("sends message with correct URL and headers", async () => {
@@ -40,27 +49,29 @@ describe("DiscordApiClient sendMessage", () => {
       },
     );
   });
+});
 
-  it("does not throw on API error response", async () => {
+describe("DiscordApiClient sendMessage error", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns false on API error response", async () => {
     mockFetch.mockResolvedValue({ ok: false, status: 403 });
     const client = new DiscordApiClient("test-token");
 
-    await expect(
-      client.sendMessage("ch-123", "Hello!"),
-    ).resolves.toBeUndefined();
+    await expect(client.sendMessage("ch-123", "Hello!")).resolves.toBe(false);
     expect(mockLogError).toHaveBeenCalledWith(
       { status: 403, channelId: "ch-123" },
       "Failed to send Discord message",
     );
   });
 
-  it("does not throw on network error", async () => {
+  it("returns false on network error", async () => {
     mockFetch.mockRejectedValue(new Error("ECONNREFUSED"));
     const client = new DiscordApiClient("test-token");
 
-    await expect(
-      client.sendMessage("ch-123", "Hello!"),
-    ).resolves.toBeUndefined();
+    await expect(client.sendMessage("ch-123", "Hello!")).resolves.toBe(false);
     expect(mockLogError).toHaveBeenCalledWith(
       { err: "ECONNREFUSED", channelId: "ch-123" },
       "Discord API request failed",

--- a/src/infrastructure/discord/discord-api.client.ts
+++ b/src/infrastructure/discord/discord-api.client.ts
@@ -5,7 +5,7 @@ export class DiscordApiClient {
 
   constructor(private botToken: string) {}
 
-  async sendMessage(channelId: string, content: string): Promise<void> {
+  async sendMessage(channelId: string, content: string): Promise<boolean> {
     const log = getLogger();
     const url = `${this.baseUrl}/channels/${channelId}/messages`;
 
@@ -24,12 +24,16 @@ export class DiscordApiClient {
           { status: response.status, channelId },
           "Failed to send Discord message",
         );
+        return false;
       }
+
+      return true;
     } catch (e) {
       log.error(
         { err: e instanceof Error ? e.message : String(e), channelId },
         "Discord API request failed",
       );
+      return false;
     }
   }
 }

--- a/src/infrastructure/discord/discord-api.client.ts
+++ b/src/infrastructure/discord/discord-api.client.ts
@@ -1,0 +1,35 @@
+import { getLogger } from "@/shared/utils/logger";
+
+export class DiscordApiClient {
+  private readonly baseUrl = "https://discord.com/api/v10";
+
+  constructor(private botToken: string) {}
+
+  async sendMessage(channelId: string, content: string): Promise<void> {
+    const log = getLogger();
+    const url = `${this.baseUrl}/channels/${channelId}/messages`;
+
+    try {
+      const response = await fetch(url, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bot ${this.botToken}`,
+        },
+        body: JSON.stringify({ content }),
+      });
+
+      if (!response.ok) {
+        log.error(
+          { status: response.status, channelId },
+          "Failed to send Discord message",
+        );
+      }
+    } catch (e) {
+      log.error(
+        { err: e instanceof Error ? e.message : String(e), channelId },
+        "Discord API request failed",
+      );
+    }
+  }
+}

--- a/src/sdk/discord/adapter/gateway-event.adapter.test.ts
+++ b/src/sdk/discord/adapter/gateway-event.adapter.test.ts
@@ -1,0 +1,321 @@
+import { describe, expect, it } from "vitest";
+import type { GatewayEvent } from "@/sdk/discord/types/gateway";
+import {
+  extractMessageData,
+  isMentionEvent,
+  parseGatewayEvent,
+  stripMentionFromContent,
+} from "./gateway-event.adapter";
+
+const makeGatewayEvent = (
+  overrides: Partial<GatewayEvent> = {},
+): GatewayEvent => ({
+  type: "GATEWAY_MESSAGE_CREATE",
+  timestamp: Date.now(),
+  data: {
+    id: "msg-123",
+    channel_id: "ch-456",
+    content: "<@bot-id> hello",
+    author: { id: "user-789", username: "testuser" },
+    mentions: [{ id: "bot-id", username: "testbot" }],
+  },
+  ...overrides,
+});
+
+describe("parseGatewayEvent - valid input", () => {
+  it("returns ok for valid gateway event", () => {
+    const result = parseGatewayEvent({
+      type: "GATEWAY_MESSAGE_CREATE",
+      timestamp: 1234567890,
+      data: { id: "1" },
+    });
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.type).toBe("GATEWAY_MESSAGE_CREATE");
+      expect(result.value.timestamp).toBe(1234567890);
+    }
+  });
+});
+
+describe("parseGatewayEvent - invalid input", () => {
+  it("returns err for null input", () => {
+    expect(parseGatewayEvent(null).ok).toBe(false);
+  });
+
+  it("returns err for string input", () => {
+    expect(parseGatewayEvent("event").ok).toBe(false);
+  });
+
+  it("returns err for missing type", () => {
+    expect(parseGatewayEvent({ timestamp: 1, data: {} }).ok).toBe(false);
+  });
+
+  it("returns err for non-string type", () => {
+    expect(parseGatewayEvent({ type: 1, timestamp: 1, data: {} }).ok).toBe(
+      false,
+    );
+  });
+
+  it("returns err for missing timestamp", () => {
+    expect(
+      parseGatewayEvent({ type: "GATEWAY_MESSAGE_CREATE", data: {} }).ok,
+    ).toBe(false);
+  });
+
+  it("returns err for non-number timestamp", () => {
+    expect(
+      parseGatewayEvent({
+        type: "GATEWAY_MESSAGE_CREATE",
+        timestamp: "now",
+        data: {},
+      }).ok,
+    ).toBe(false);
+  });
+
+  it("returns err for missing data", () => {
+    expect(
+      parseGatewayEvent({
+        type: "GATEWAY_MESSAGE_CREATE",
+        timestamp: 1,
+      }).ok,
+    ).toBe(false);
+  });
+
+  it("returns err for null data", () => {
+    expect(
+      parseGatewayEvent({
+        type: "GATEWAY_MESSAGE_CREATE",
+        timestamp: 1,
+        data: null,
+      }).ok,
+    ).toBe(false);
+  });
+});
+
+describe("isMentionEvent", () => {
+  it("returns true when bot is mentioned in MESSAGE_CREATE", () => {
+    const event = makeGatewayEvent();
+    expect(isMentionEvent(event, "bot-id")).toBe(true);
+  });
+
+  it("returns false when bot is not mentioned", () => {
+    const event = makeGatewayEvent({
+      data: {
+        id: "msg-123",
+        channel_id: "ch-456",
+        content: "hello",
+        author: { id: "user-789", username: "testuser" },
+        mentions: [],
+      },
+    });
+    expect(isMentionEvent(event, "bot-id")).toBe(false);
+  });
+
+  it("returns false for non-MESSAGE_CREATE event", () => {
+    const event = makeGatewayEvent({ type: "GATEWAY_MESSAGE_REACTION_ADD" });
+    expect(isMentionEvent(event, "bot-id")).toBe(false);
+  });
+
+  it("returns false when data has no mentions array", () => {
+    const event = makeGatewayEvent({ data: { id: "1" } });
+    expect(isMentionEvent(event, "bot-id")).toBe(false);
+  });
+
+  it("returns false when mentions array is empty", () => {
+    const event = makeGatewayEvent({
+      data: {
+        id: "msg-123",
+        channel_id: "ch-456",
+        content: "hello",
+        author: { id: "user-789", username: "testuser" },
+        mentions: [],
+      },
+    });
+    expect(isMentionEvent(event, "bot-id")).toBe(false);
+  });
+
+  it("returns true when bot is one of multiple mentions", () => {
+    const event = makeGatewayEvent({
+      data: {
+        id: "msg-123",
+        channel_id: "ch-456",
+        content: "<@other> <@bot-id> hello",
+        author: { id: "user-789", username: "testuser" },
+        mentions: [
+          { id: "other", username: "otheruser" },
+          { id: "bot-id", username: "testbot" },
+        ],
+      },
+    });
+    expect(isMentionEvent(event, "bot-id")).toBe(true);
+  });
+});
+
+describe("extractMessageData - valid input", () => {
+  it("returns ok for valid message data", () => {
+    const event = makeGatewayEvent();
+    const result = extractMessageData(event);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.id).toBe("msg-123");
+      expect(result.value.channel_id).toBe("ch-456");
+      expect(result.value.content).toBe("<@bot-id> hello");
+      expect(result.value.author.id).toBe("user-789");
+      expect(result.value.mentions).toHaveLength(1);
+    }
+  });
+
+  it("extracts optional guild_id", () => {
+    const event = makeGatewayEvent({
+      data: {
+        id: "msg-123",
+        channel_id: "ch-456",
+        content: "hello",
+        author: { id: "user-789", username: "testuser" },
+        mentions: [],
+        guild_id: "guild-1",
+      },
+    });
+    const result = extractMessageData(event);
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.value.guild_id).toBe("guild-1");
+  });
+
+  it("sets guild_id to undefined when not present", () => {
+    const event = makeGatewayEvent();
+    const result = extractMessageData(event);
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.value.guild_id).toBeUndefined();
+  });
+
+  it("extracts bot flag from author", () => {
+    const event = makeGatewayEvent({
+      data: {
+        id: "msg-123",
+        channel_id: "ch-456",
+        content: "hello",
+        author: { id: "user-789", username: "testuser", bot: true },
+        mentions: [],
+      },
+    });
+    const result = extractMessageData(event);
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.value.author.bot).toBe(true);
+  });
+});
+
+describe("extractMessageData - invalid input (part 1)", () => {
+  it("returns err when data is not an object", () => {
+    const event = makeGatewayEvent({ data: "invalid" });
+    expect(extractMessageData(event).ok).toBe(false);
+  });
+
+  it("returns err when data is null", () => {
+    const event: GatewayEvent = {
+      type: "GATEWAY_MESSAGE_CREATE",
+      timestamp: 1,
+      data: null,
+    };
+    expect(extractMessageData(event).ok).toBe(false);
+  });
+
+  it("returns err for missing id", () => {
+    const event = makeGatewayEvent({
+      data: {
+        channel_id: "ch",
+        content: "hi",
+        author: { id: "u1", username: "user" },
+        mentions: [],
+      },
+    });
+    expect(extractMessageData(event).ok).toBe(false);
+  });
+
+  it("returns err for missing channel_id", () => {
+    const event = makeGatewayEvent({
+      data: {
+        id: "msg-1",
+        content: "hi",
+        author: { id: "u1", username: "user" },
+        mentions: [],
+      },
+    });
+    expect(extractMessageData(event).ok).toBe(false);
+  });
+});
+
+describe("extractMessageData - invalid input (part 2)", () => {
+  it("returns err for missing content", () => {
+    const event = makeGatewayEvent({
+      data: {
+        id: "msg-1",
+        channel_id: "ch",
+        author: { id: "u1", username: "user" },
+        mentions: [],
+      },
+    });
+    expect(extractMessageData(event).ok).toBe(false);
+  });
+
+  it("returns err for missing author", () => {
+    const event = makeGatewayEvent({
+      data: {
+        id: "msg-1",
+        channel_id: "ch",
+        content: "hi",
+        mentions: [],
+      },
+    });
+    expect(extractMessageData(event).ok).toBe(false);
+  });
+
+  it("returns err for missing mentions", () => {
+    const event = makeGatewayEvent({
+      data: {
+        id: "msg-1",
+        channel_id: "ch",
+        content: "hi",
+        author: { id: "u1", username: "user" },
+      },
+    });
+    expect(extractMessageData(event).ok).toBe(false);
+  });
+});
+
+describe("stripMentionFromContent", () => {
+  it("strips <@id> mention from content", () => {
+    expect(stripMentionFromContent("<@123456> hello", "123456")).toBe("hello");
+  });
+
+  it("strips <@!id> nickname mention from content", () => {
+    expect(stripMentionFromContent("<@!123456> hello", "123456")).toBe("hello");
+  });
+
+  it("returns content unchanged when no mention present", () => {
+    expect(stripMentionFromContent("hello world", "123456")).toBe(
+      "hello world",
+    );
+  });
+
+  it("strips multiple mentions of the same bot", () => {
+    expect(
+      stripMentionFromContent("<@123456> hello <@123456> again", "123456"),
+    ).toBe("hello  again");
+  });
+
+  it("does not strip other user mentions", () => {
+    expect(stripMentionFromContent("<@999999> hello", "123456")).toBe(
+      "<@999999> hello",
+    );
+  });
+
+  it("returns empty string when content is only a mention", () => {
+    expect(stripMentionFromContent("<@123456>", "123456")).toBe("");
+  });
+
+  it("handles content with extra whitespace", () => {
+    expect(stripMentionFromContent("  <@123456>   hello   ", "123456")).toBe(
+      "hello",
+    );
+  });
+});

--- a/src/sdk/discord/adapter/gateway-event.adapter.ts
+++ b/src/sdk/discord/adapter/gateway-event.adapter.ts
@@ -1,0 +1,103 @@
+import type {
+  GatewayEvent,
+  GatewayMessageData,
+} from "@/sdk/discord/types/gateway";
+import { ValidationError } from "@/shared/types/errors";
+import { err, ok, type Result } from "@/shared/types/result";
+
+export function parseGatewayEvent(raw: unknown): Result<GatewayEvent> {
+  if (typeof raw !== "object" || raw === null) {
+    return err(new ValidationError("Gateway event must be an object"));
+  }
+
+  const obj = raw as Record<string, unknown>;
+
+  if (typeof obj.type !== "string") {
+    return err(new ValidationError("Gateway event must have a type string"));
+  }
+
+  if (typeof obj.timestamp !== "number") {
+    return err(
+      new ValidationError("Gateway event must have a timestamp number"),
+    );
+  }
+
+  if (obj.data === undefined || obj.data === null) {
+    return err(new ValidationError("Gateway event must have data"));
+  }
+
+  return ok({
+    type: obj.type,
+    timestamp: obj.timestamp,
+    data: obj.data,
+  });
+}
+
+export function isMentionEvent(
+  event: GatewayEvent,
+  botApplicationId: string,
+): boolean {
+  if (event.type !== "GATEWAY_MESSAGE_CREATE") return false;
+
+  const data = event.data as Record<string, unknown>;
+  if (!(data && Array.isArray(data.mentions))) return false;
+
+  return data.mentions.some(
+    (m: Record<string, unknown>) => m.id === botApplicationId,
+  );
+}
+
+export function extractMessageData(
+  event: GatewayEvent,
+): Result<GatewayMessageData> {
+  const data = event.data as Record<string, unknown>;
+
+  if (typeof data !== "object" || data === null) {
+    return err(new ValidationError("Event data must be an object"));
+  }
+
+  if (typeof data.id !== "string") {
+    return err(new ValidationError("Message data must have id string"));
+  }
+
+  if (typeof data.channel_id !== "string") {
+    return err(new ValidationError("Message data must have channel_id string"));
+  }
+
+  if (typeof data.content !== "string") {
+    return err(new ValidationError("Message data must have content string"));
+  }
+
+  if (!data.author || typeof data.author !== "object") {
+    return err(new ValidationError("Message data must have author object"));
+  }
+
+  const author = data.author as Record<string, unknown>;
+  if (typeof author.id !== "string" || typeof author.username !== "string") {
+    return err(new ValidationError("Author must have id and username strings"));
+  }
+
+  if (!Array.isArray(data.mentions)) {
+    return err(new ValidationError("Message data must have mentions array"));
+  }
+
+  return ok({
+    id: data.id,
+    channel_id: data.channel_id,
+    content: data.content,
+    author: {
+      id: author.id,
+      username: author.username,
+      bot: typeof author.bot === "boolean" ? author.bot : undefined,
+    },
+    mentions: data.mentions as Array<{ id: string; username: string }>,
+    guild_id: typeof data.guild_id === "string" ? data.guild_id : undefined,
+  });
+}
+
+export function stripMentionFromContent(
+  content: string,
+  applicationId: string,
+): string {
+  return content.replace(new RegExp(`<@!?${applicationId}>`, "g"), "").trim();
+}

--- a/src/sdk/discord/types/gateway.ts
+++ b/src/sdk/discord/types/gateway.ts
@@ -1,0 +1,25 @@
+export interface GatewayEvent {
+  type: string;
+  timestamp: number;
+  data: unknown;
+}
+
+export interface GatewayMessageAuthor {
+  id: string;
+  username: string;
+  bot?: boolean;
+}
+
+export interface GatewayMessageMention {
+  id: string;
+  username: string;
+}
+
+export interface GatewayMessageData {
+  id: string;
+  channel_id: string;
+  content: string;
+  author: GatewayMessageAuthor;
+  mentions: GatewayMessageMention[];
+  guild_id?: string;
+}

--- a/src/sdk/discord/types/index.ts
+++ b/src/sdk/discord/types/index.ts
@@ -11,3 +11,10 @@ export type {
   DomainResponse,
   InteractionType,
 } from "./domain";
+
+export type {
+  GatewayEvent,
+  GatewayMessageAuthor,
+  GatewayMessageData,
+  GatewayMessageMention,
+} from "./gateway";

--- a/src/server/hono.test.ts
+++ b/src/server/hono.test.ts
@@ -66,9 +66,7 @@ describe("createApp with deps", () => {
 
   it("mounts discord route when deps are provided", async () => {
     vi.doMock("@/server/middleware/verify-discord", () => ({
-      verifyDiscord: async (_c: unknown, next: () => Promise<void>) => {
-        await next();
-      },
+      verifyDiscordSignature: async () => null,
     }));
     vi.doMock("@/sdk/discord/adapter/interaction.adapter", () => ({
       toDomain: () => ({
@@ -84,8 +82,15 @@ describe("createApp with deps", () => {
     const mockHandler = {
       handle: vi.fn().mockResolvedValue({ type: 1 }),
     };
+    const mockMessageHandler = {
+      handleGatewayEvent: vi.fn(),
+    };
 
-    const app = createApp({ interactionHandler: mockHandler as never });
+    const app = createApp({
+      interactionHandler: mockHandler as never,
+      messageHandler: mockMessageHandler as never,
+      botToken: "test-token",
+    });
     const res = await app.request("/api/webhooks/discord", {
       method: "POST",
       headers: { "Content-Type": "application/json" },

--- a/src/server/hono.ts
+++ b/src/server/hono.ts
@@ -1,11 +1,16 @@
 import { Hono } from "hono";
 import type { InteractionHandler } from "@/bot/handlers/interaction.handler";
+import type { MessageHandler } from "@/bot/handlers/message.handler";
 import { logger } from "@/server/middleware/logger";
 import { createDiscordRoute } from "@/server/routes/discord.route";
 import { health } from "@/server/routes/health.route";
 import { getLogger } from "@/shared/utils/logger";
 
-export function createApp(deps?: { interactionHandler: InteractionHandler }) {
+export function createApp(deps?: {
+  interactionHandler: InteractionHandler;
+  messageHandler: MessageHandler;
+  botToken: string;
+}) {
   const app = new Hono();
 
   app.use("*", logger);

--- a/src/server/middleware/verify-discord.ts
+++ b/src/server/middleware/verify-discord.ts
@@ -1,10 +1,12 @@
 import { etc, verifyAsync } from "@noble/ed25519";
-import type { MiddlewareHandler } from "hono";
+import type { Context, MiddlewareHandler } from "hono";
 import { env } from "@/app/config/env";
 import { HTTP_UNAUTHORIZED } from "@/shared/utils/http-status";
 import { getLogger } from "@/shared/utils/logger";
 
-export const verifyDiscord: MiddlewareHandler = async (c, next) => {
+export async function verifyDiscordSignature(
+  c: Context,
+): Promise<Response | null> {
   const log = getLogger();
   const publicKey = env.DISCORD_PUBLIC_KEY;
 
@@ -45,5 +47,11 @@ export const verifyDiscord: MiddlewareHandler = async (c, next) => {
   }
 
   log.debug("Discord signature verification passed");
+  return null;
+}
+
+export const verifyDiscord: MiddlewareHandler = async (c, next) => {
+  const error = await verifyDiscordSignature(c);
+  if (error) return error;
   await next();
 };

--- a/src/server/routes/discord.route.test.ts
+++ b/src/server/routes/discord.route.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { InteractionHandler } from "@/bot/handlers/interaction.handler";
+import type { MessageHandler } from "@/bot/handlers/message.handler";
 import type { DomainInteraction } from "@/sdk/discord/types/domain";
 
 const mockLog = {
@@ -12,9 +13,7 @@ const mockLog = {
 vi.mock("@/shared/utils/logger", () => ({ getLogger: () => mockLog }));
 
 vi.mock("@/server/middleware/verify-discord", () => ({
-  verifyDiscord: async (_c: unknown, next: () => Promise<void>) => {
-    await next();
-  },
+  verifyDiscordSignature: async () => null,
 }));
 
 const mockToDomain = vi.fn();
@@ -27,11 +26,30 @@ vi.mock("@/sdk/discord/adapter/response.adapter", () => ({
   toDiscord: (...args: unknown[]) => mockToDiscord(...args),
 }));
 
+const mockParseGatewayEvent = vi.fn();
+vi.mock("@/sdk/discord/adapter/gateway-event.adapter", () => ({
+  parseGatewayEvent: (...args: unknown[]) => mockParseGatewayEvent(...args),
+}));
+
+const mockHandleGatewayEvent = vi.fn();
+
 const { createDiscordRoute } = await import("@/server/routes/discord.route");
 
 function createMockHandler() {
   return { handle: vi.fn() } as unknown as InteractionHandler;
 }
+
+function createMockMessageHandler() {
+  return {
+    handleGatewayEvent: mockHandleGatewayEvent,
+  } as unknown as MessageHandler;
+}
+
+const testDeps = {
+  interactionHandler: createMockHandler(),
+  messageHandler: createMockMessageHandler(),
+  botToken: "test-bot-token",
+};
 
 describe("createDiscordRoute - error cases", () => {
   beforeEach(() => {
@@ -47,7 +65,7 @@ describe("createDiscordRoute - error cases", () => {
       ok: false,
       error: new Error("missing interaction id"),
     });
-    const app = createDiscordRoute({ interactionHandler: createMockHandler() });
+    const app = createDiscordRoute(testDeps);
 
     const res = await app.request("/", {
       method: "POST",
@@ -73,7 +91,10 @@ describe("createDiscordRoute - error cases", () => {
       },
     });
     vi.mocked(handler).handle = vi.fn().mockRejectedValue(new Error("boom"));
-    const app = createDiscordRoute({ interactionHandler: handler });
+    const app = createDiscordRoute({
+      ...testDeps,
+      interactionHandler: handler,
+    });
 
     const res = await app.request("/", {
       method: "POST",
@@ -95,7 +116,10 @@ describe("createDiscordRoute - invalid body", () => {
 
   it("returns 500 when body is not valid JSON", async () => {
     const handler = createMockHandler();
-    const app = createDiscordRoute({ interactionHandler: handler });
+    const app = createDiscordRoute({
+      ...testDeps,
+      interactionHandler: handler,
+    });
 
     const res = await app.request("/", {
       method: "POST",
@@ -107,7 +131,7 @@ describe("createDiscordRoute - invalid body", () => {
   });
 });
 
-describe("createDiscordRoute - success cases", () => {
+describe("createDiscordRoute - ping interaction", () => {
   beforeEach(() => {
     vi.restoreAllMocks();
     mockToDomain.mockReset();
@@ -115,7 +139,6 @@ describe("createDiscordRoute - success cases", () => {
   });
 
   it("returns 200 with pong for ping interaction", async () => {
-    const handler = createMockHandler();
     const interaction: DomainInteraction = {
       id: "1",
       type: "ping",
@@ -123,10 +146,14 @@ describe("createDiscordRoute - success cases", () => {
       userId: "",
       raw: {},
     };
+    const handler = createMockHandler();
     mockToDomain.mockReturnValue({ ok: true, value: interaction });
     vi.mocked(handler).handle = vi.fn().mockResolvedValue({ type: 1 });
     mockToDiscord.mockReturnValue({ type: 1 });
-    const app = createDiscordRoute({ interactionHandler: handler });
+    const app = createDiscordRoute({
+      ...testDeps,
+      interactionHandler: handler,
+    });
 
     const res = await app.request("/", {
       method: "POST",
@@ -138,9 +165,16 @@ describe("createDiscordRoute - success cases", () => {
     expect(handler.handle).toHaveBeenCalledWith(interaction);
     expect(mockToDiscord).toHaveBeenCalledWith({ type: 1 });
   });
+});
+
+describe("createDiscordRoute - command interaction", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    mockToDomain.mockReset();
+    mockToDiscord.mockReset();
+  });
 
   it("returns 200 with command response", async () => {
-    const handler = createMockHandler();
     const interaction: DomainInteraction = {
       id: "2",
       type: "command",
@@ -150,10 +184,14 @@ describe("createDiscordRoute - success cases", () => {
       raw: {},
     };
     const domainResponse = { type: 4, data: { content: "Pong!" } };
+    const handler = createMockHandler();
     mockToDomain.mockReturnValue({ ok: true, value: interaction });
     vi.mocked(handler).handle = vi.fn().mockResolvedValue(domainResponse);
-    mockToDiscord.mockReturnValue({ type: 4, data: { content: "Pong!" } });
-    const app = createDiscordRoute({ interactionHandler: handler });
+    mockToDiscord.mockReturnValue(domainResponse);
+    const app = createDiscordRoute({
+      ...testDeps,
+      interactionHandler: handler,
+    });
 
     const res = await app.request("/", {
       method: "POST",
@@ -162,6 +200,79 @@ describe("createDiscordRoute - success cases", () => {
     });
 
     expect(res.status).toBe(200);
-    expect(await res.json()).toEqual({ type: 4, data: { content: "Pong!" } });
+    expect(await res.json()).toEqual(domainResponse);
+  });
+});
+
+describe("createDiscordRoute - gateway event routing", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    mockParseGatewayEvent.mockReset();
+    mockHandleGatewayEvent.mockReset();
+    mockToDomain.mockReset();
+  });
+
+  it("routes gateway event to messageHandler", async () => {
+    const event = { type: "GATEWAY_MESSAGE_CREATE", timestamp: 1, data: {} };
+    mockParseGatewayEvent.mockReturnValue({ ok: true, value: event });
+    mockHandleGatewayEvent.mockResolvedValue(undefined);
+    const app = createDiscordRoute(testDeps);
+
+    const res = await app.request("/", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "x-discord-gateway-token": "test-bot-token",
+      },
+      body: JSON.stringify(event),
+    });
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: true });
+    expect(mockHandleGatewayEvent).toHaveBeenCalledWith(event);
+    expect(mockToDomain).not.toHaveBeenCalled();
+  });
+
+  it("returns 401 for invalid gateway token", async () => {
+    const app = createDiscordRoute(testDeps);
+
+    const res = await app.request("/", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "x-discord-gateway-token": "wrong-token",
+      },
+      body: JSON.stringify({}),
+    });
+
+    expect(res.status).toBe(401);
+  });
+});
+
+describe("createDiscordRoute - gateway invalid payload", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    mockParseGatewayEvent.mockReset();
+    mockHandleGatewayEvent.mockReset();
+  });
+
+  it("returns 200 for invalid gateway event payload", async () => {
+    mockParseGatewayEvent.mockReturnValue({
+      ok: false,
+      error: { message: "bad" },
+    });
+    const app = createDiscordRoute(testDeps);
+
+    const res = await app.request("/", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "x-discord-gateway-token": "test-bot-token",
+      },
+      body: JSON.stringify({}),
+    });
+
+    expect(res.status).toBe(200);
+    expect(mockHandleGatewayEvent).not.toHaveBeenCalled();
   });
 });

--- a/src/server/routes/discord.route.test.ts
+++ b/src/server/routes/discord.route.test.ts
@@ -256,7 +256,7 @@ describe("createDiscordRoute - gateway invalid payload", () => {
     mockHandleGatewayEvent.mockReset();
   });
 
-  it("returns 200 for invalid gateway event payload", async () => {
+  it("returns 400 for invalid gateway event payload", async () => {
     mockParseGatewayEvent.mockReturnValue({
       ok: false,
       error: { message: "bad" },
@@ -272,7 +272,8 @@ describe("createDiscordRoute - gateway invalid payload", () => {
       body: JSON.stringify({}),
     });
 
-    expect(res.status).toBe(200);
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ ok: false, error: "bad" });
     expect(mockHandleGatewayEvent).not.toHaveBeenCalled();
   });
 });

--- a/src/server/routes/discord.route.ts
+++ b/src/server/routes/discord.route.ts
@@ -1,24 +1,52 @@
 import { Hono } from "hono";
 import type { InteractionHandler } from "@/bot/handlers/interaction.handler";
+import type { MessageHandler } from "@/bot/handlers/message.handler";
+import { parseGatewayEvent } from "@/sdk/discord/adapter/gateway-event.adapter";
 import { toDomain } from "@/sdk/discord/adapter/interaction.adapter";
 import { toDiscord } from "@/sdk/discord/adapter/response.adapter";
-import { verifyDiscord } from "@/server/middleware/verify-discord";
+import { verifyDiscordSignature } from "@/server/middleware/verify-discord";
 import {
   HTTP_BAD_REQUEST,
   HTTP_INTERNAL_SERVER_ERROR,
   HTTP_OK,
+  HTTP_UNAUTHORIZED,
 } from "@/shared/utils/http-status";
 import { getLogger } from "@/shared/utils/logger";
 
 export function createDiscordRoute(deps: {
   interactionHandler: InteractionHandler;
+  messageHandler: MessageHandler;
+  botToken: string;
 }): Hono {
   const discord = new Hono();
   const log = getLogger();
 
-  discord.use("*", verifyDiscord);
-
   discord.post("/", async (c) => {
+    const gatewayToken = c.req.header("x-discord-gateway-token");
+
+    if (gatewayToken) {
+      if (gatewayToken !== deps.botToken) {
+        return c.json({ error: "Invalid gateway token" }, HTTP_UNAUTHORIZED);
+      }
+
+      const raw = await c.req.json();
+      const eventResult = parseGatewayEvent(raw);
+
+      if (!eventResult.ok) {
+        log.warn(
+          { error: eventResult.error.message },
+          "Invalid gateway event payload",
+        );
+        return c.json({ ok: true }, HTTP_OK);
+      }
+
+      await deps.messageHandler.handleGatewayEvent(eventResult.value);
+      return c.json({ ok: true }, HTTP_OK);
+    }
+
+    const verifyResult = await verifyDiscordSignature(c);
+    if (verifyResult) return verifyResult;
+
     const raw = await c.req.json();
     const result = toDomain(raw);
 

--- a/src/server/routes/discord.route.ts
+++ b/src/server/routes/discord.route.ts
@@ -37,7 +37,10 @@ export function createDiscordRoute(deps: {
           { error: eventResult.error.message },
           "Invalid gateway event payload",
         );
-        return c.json({ ok: true }, HTTP_OK);
+        return c.json(
+          { ok: false, error: eventResult.error.message },
+          HTTP_BAD_REQUEST,
+        );
       }
 
       await deps.messageHandler.handleGatewayEvent(eventResult.value);


### PR DESCRIPTION
# チケット

close #37

# 概要

Discord Gatewayからのイベントを受信し、Botへのメンションメッセージを検知してAI応答を返す機能を追加しました。

### 変更内容

- **Gatewayイベント型定義**: `GatewayEvent`, `GatewayMessageData` などの型を追加
- **Gatewayイベントアダプタ**: イベントのパース、メンション判定、メッセージデータ抽出、メンション除去を実装
- **Discord APIクライアント**: メッセージ送信用の `DiscordApiClient` を追加
- **MessageHandler**: メンション検知 → AI呼び出し → メッセージ送信のフローを実装
- **verify-discordミドルウェア**: `verifyDiscordSignature` 関数に分離し、ルート内で呼び出し可能にリファクタリング
- **Discordルート**: `x-discord-gateway-token` ヘッダーによるGatewayイベントルーティングを追加
- **createApp / Bootstrap**: `messageHandler` と `botToken` の依存関係を伝播

# その他

resolves #37