### PR TITLE
✨ スレッド対応・ギルドコマンド登録・Codex設定のカスタマイズを追加 #33

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,11 @@
 NODE_ENV=development
 REDIS_URL=redis://localhost:6379
 OPENAI_API_KEY=your-api-key
+DISCORD_BOT_TOKEN=discord-bot-token
+DISCORD_APPLICATION_ID=discord-application-id
+DISCORD_PUBLIC_KEY=discord-public-key
+DISCORD_GUILD_ID=discord-guild-id
+TUNNEL_TOKEN=tunnel-token
+CODEX_BASE_URL=codex-base-url
+CODEX_API_KEY=codex-api-key
+CODEX_MODEL=codex-model

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,5 +20,7 @@ COPY package.json pnpm-lock.yaml ./
 RUN pnpm install --frozen-lockfile --prod
 
 COPY --from=builder /app/dist ./dist
+COPY --from=builder /app/src/app/config/config.yaml ./src/app/config/config.yaml
 
+ENV NODE_ENV=production
 CMD ["node", "dist/index.js"]

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -4,7 +4,7 @@ tasks:
   build:
     desc: Build with esbuild
     cmds:
-      - nix develop --command pnpm exec esbuild src/index.ts --bundle --platform=node --format=esm --outdir=dist
+      - nix develop --command pnpm exec tsx esbuild.config.ts
 
   dev:
     desc: Run in development mode
@@ -41,3 +41,23 @@ tasks:
     desc: Run pre-commit hooks manually
     cmds:
       - nix develop --command lefthook run pre-commit
+
+  docker:build:
+    desc: Build Docker images
+    cmds:
+      - docker compose build
+
+  docker:up:
+    desc: Start Docker containers
+    cmds:
+      - docker compose up
+
+  docker:down:
+    desc: Stop and remove Docker containers
+    cmds:
+      - docker compose down
+
+  docker:logs:
+    desc: View Docker container logs
+    cmds:
+      - docker compose logs -f

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,12 @@ services:
     environment:
       - DISCORD_PUBLIC_KEY=${DISCORD_PUBLIC_KEY}
       - DISCORD_BOT_TOKEN=${DISCORD_BOT_TOKEN}
+      - DISCORD_APPLICATION_ID=${DISCORD_APPLICATION_ID}
+      - DISCORD_GUILD_ID=${DISCORD_GUILD_ID}
       - OPENAI_API_KEY=${OPENAI_API_KEY}
+      - CODEX_BASE_URL=${CODEX_BASE_URL}
+      - CODEX_API_KEY=${CODEX_API_KEY}
+      - CODEX_MODEL=${CODEX_MODEL}
       - REDIS_URL=redis://redis:6379
     depends_on:
       redis:
@@ -21,3 +26,12 @@ services:
       interval: 5s
       timeout: 3s
       retries: 5
+
+  cloudflared:
+    image: cloudflare/cloudflared:2025.11.1
+    command: tunnel --no-autoupdate run
+    environment:
+      - TUNNEL_TOKEN=${TUNNEL_TOKEN}
+    depends_on:
+      - app
+    restart: unless-stopped

--- a/esbuild.config.ts
+++ b/esbuild.config.ts
@@ -1,0 +1,10 @@
+import { build } from "esbuild";
+
+await build({
+  entryPoints: ["src/index.ts"],
+  bundle: true,
+  platform: "node",
+  format: "esm",
+  outdir: "dist",
+  packages: "external",
+});

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "dist/index.js",
   "type": "module",
   "scripts": {
-    "build": "esbuild src/index.ts --bundle --platform=node --format=esm --outdir=dist",
+    "build": "tsx esbuild.config.ts",
     "dev": "tsx watch src/index.ts",
     "lint": "biome lint ./src",
     "fmt": "biome format --write ./src",

--- a/src/ai/client/codex.client.test.ts
+++ b/src/ai/client/codex.client.test.ts
@@ -3,10 +3,12 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 const mockStartThread = vi.fn();
 const mockResumeThread = vi.fn();
 const mockRun = vi.fn();
+const mockCodexConstructor = vi.fn();
 
 vi.mock("@openai/codex-sdk", () => ({
   // biome-ignore lint/complexity/useArrowFunction: constructor mock requires function expression
-  Codex: vi.fn().mockImplementation(function () {
+  Codex: vi.fn().mockImplementation(function (options?: unknown) {
+    mockCodexConstructor(options);
     return {
       startThread: mockStartThread,
       resumeThread: mockResumeThread,
@@ -14,10 +16,73 @@ vi.mock("@openai/codex-sdk", () => ({
   }),
 }));
 
-async function createClient() {
+async function createClient(
+  apiKey = "test-api-key",
+  options?: { baseUrl?: string; model?: string },
+) {
   const { CodexClient } = await import("./codex.client");
-  return new CodexClient("test-api-key");
+  return new CodexClient(apiKey, options);
 }
+
+describe("CodexClient constructor", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("passes apiKey to Codex SDK", async () => {
+    await createClient("my-key");
+
+    expect(mockCodexConstructor).toHaveBeenCalledWith({
+      apiKey: "my-key",
+      baseUrl: undefined,
+    });
+  });
+
+  it("passes baseUrl option to Codex SDK", async () => {
+    await createClient("my-key", { baseUrl: "https://custom.api" });
+
+    expect(mockCodexConstructor).toHaveBeenCalledWith({
+      apiKey: "my-key",
+      baseUrl: "https://custom.api",
+    });
+  });
+
+  it("passes model option and uses it in startThread", async () => {
+    mockStartThread.mockReturnValue({
+      run: mockRun,
+      id: "thread-model",
+    });
+    mockRun.mockResolvedValue({
+      finalResponse: "Response",
+      usage: null,
+    });
+
+    const client = await createClient("my-key", { model: "custom-model" });
+    await client.chat(null, "Hello");
+
+    expect(mockStartThread).toHaveBeenCalledWith(
+      expect.objectContaining({ model: "custom-model" }),
+    );
+  });
+
+  it("defaults model to codex-mini when not provided", async () => {
+    mockStartThread.mockReturnValue({
+      run: mockRun,
+      id: "thread-default",
+    });
+    mockRun.mockResolvedValue({
+      finalResponse: "Response",
+      usage: null,
+    });
+
+    const client = await createClient("my-key");
+    await client.chat(null, "Hello");
+
+    expect(mockStartThread).toHaveBeenCalledWith(
+      expect.objectContaining({ model: "codex-mini" }),
+    );
+  });
+});
 
 describe("CodexClient chat new thread", () => {
   beforeEach(() => {
@@ -45,6 +110,7 @@ describe("CodexClient chat new thread", () => {
       sandboxMode: "read-only",
       networkAccessEnabled: true,
       webSearchMode: "live",
+      skipGitRepoCheck: true,
     });
     expect(result.response).toBe("Hello from AI");
     expect(result.threadId).toBe("new-thread-123");
@@ -83,7 +149,13 @@ describe("CodexClient chat existing thread", () => {
   it("resumes existing thread when threadId is provided", async () => {
     const client = await createClient();
     const result = await client.chat("existing-thread-456", "Continue");
-    expect(mockResumeThread).toHaveBeenCalledWith("existing-thread-456");
+    expect(mockResumeThread).toHaveBeenCalledWith("existing-thread-456", {
+      model: "codex-mini",
+      sandboxMode: "read-only",
+      networkAccessEnabled: true,
+      webSearchMode: "live",
+      skipGitRepoCheck: true,
+    });
     expect(mockStartThread).not.toHaveBeenCalled();
     expect(result.response).toBe("Continued response");
     expect(result.threadId).toBe("existing-thread-456");

--- a/src/ai/client/codex.client.ts
+++ b/src/ai/client/codex.client.ts
@@ -8,20 +8,25 @@ export interface ChatResult {
 
 export class CodexClient {
   private codex: Codex;
+  private model: string | undefined;
 
-  constructor(apiKey: string) {
-    this.codex = new Codex({ apiKey });
+  constructor(apiKey: string, options?: { baseUrl?: string; model?: string }) {
+    this.codex = new Codex({ apiKey, baseUrl: options?.baseUrl });
+    this.model = options?.model;
   }
 
   async chat(threadId: string | null, input: Input): Promise<ChatResult> {
+    const threadOptions = {
+      model: this.model ?? "codex-mini",
+      sandboxMode: "read-only" as const,
+      networkAccessEnabled: true,
+      webSearchMode: "live" as const,
+      skipGitRepoCheck: true,
+    };
+
     const thread = threadId
-      ? this.codex.resumeThread(threadId)
-      : this.codex.startThread({
-          model: "codex-mini",
-          sandboxMode: "read-only",
-          networkAccessEnabled: true,
-          webSearchMode: "live",
-        });
+      ? this.codex.resumeThread(threadId, threadOptions)
+      : this.codex.startThread(threadOptions);
 
     const turn = await thread.run(input);
     const id = thread.id;

--- a/src/ai/services/ai.service.test.ts
+++ b/src/ai/services/ai.service.test.ts
@@ -337,3 +337,63 @@ describe("AIService chat empty thread ID from Redis", () => {
     );
   });
 });
+
+describe("AIService linkThreadChannel", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("copies thread mapping to thread channel with TTL", async () => {
+    mockRedisGet.mockResolvedValue("thread-abc");
+    mockRedisSet.mockResolvedValue(undefined);
+    const service = await createService();
+
+    await service.linkThreadChannel("channel-orig", "thread-ch");
+
+    expect(mockRedisGet).toHaveBeenCalledWith("thread:channel-orig");
+    expect(mockRedisSet).toHaveBeenCalledWith(
+      "thread:thread-ch",
+      "thread-abc",
+      {
+        ttlMs: 86400000,
+      },
+    );
+  });
+
+  it("does not call redis.set when original channel has no thread mapping", async () => {
+    mockRedisGet.mockResolvedValue(null);
+    const service = await createService();
+
+    await service.linkThreadChannel("channel-orig", "thread-ch");
+
+    expect(mockRedisSet).not.toHaveBeenCalled();
+  });
+
+  it("does not call redis.set when thread ID is empty string", async () => {
+    mockRedisGet.mockResolvedValue("");
+    const service = await createService();
+
+    await service.linkThreadChannel("channel-orig", "thread-ch");
+
+    expect(mockRedisSet).not.toHaveBeenCalled();
+  });
+
+  it("propagates error when redis.get fails", async () => {
+    mockRedisGet.mockRejectedValue(new Error("connection lost"));
+    const service = await createService();
+
+    await expect(
+      service.linkThreadChannel("channel-orig", "thread-ch"),
+    ).rejects.toThrow("connection lost");
+  });
+
+  it("propagates error when redis.set fails", async () => {
+    mockRedisGet.mockResolvedValue("thread-abc");
+    mockRedisSet.mockRejectedValue(new Error("write error"));
+    const service = await createService();
+
+    await expect(
+      service.linkThreadChannel("channel-orig", "thread-ch"),
+    ).rejects.toThrow("write error");
+  });
+});

--- a/src/ai/services/ai.service.ts
+++ b/src/ai/services/ai.service.ts
@@ -59,4 +59,16 @@ export class AIService {
   async resetConversation(channelId: string): Promise<void> {
     await this.redis.delete(`thread:${channelId}`);
   }
+
+  async linkThreadChannel(
+    originalChannelId: string,
+    threadChannelId: string,
+  ): Promise<void> {
+    const threadId = await this.redis.get(`thread:${originalChannelId}`);
+    if (threadId) {
+      await this.redis.set(`thread:${threadChannelId}`, threadId, {
+        ttlMs: DEFAULT_TTL_MS,
+      });
+    }
+  }
 }

--- a/src/app/bootstrap.test.ts
+++ b/src/app/bootstrap.test.ts
@@ -19,6 +19,7 @@ const mockStart = vi.fn().mockResolvedValue(undefined);
 const mockStop = vi.fn();
 const mockRedisDisconnect = vi.fn().mockResolvedValue(undefined);
 const mockRedisConnect = vi.fn().mockResolvedValue(undefined);
+const mockRegisterGuildCommands = vi.fn().mockResolvedValue(undefined);
 
 function setupMocks(
   config: Record<string, unknown>,
@@ -31,9 +32,13 @@ function setupMocks(
     env: {
       NODE_ENV: "test",
       OPENAI_API_KEY: "test-key",
+      CODEX_API_KEY: undefined,
+      CODEX_BASE_URL: undefined,
+      CODEX_MODEL: undefined,
       DISCORD_PUBLIC_KEY: "test-pk",
       DISCORD_BOT_TOKEN: "test-bot-token",
       DISCORD_APPLICATION_ID: "test-app-id",
+      DISCORD_GUILD_ID: undefined,
       ...envOverrides,
     },
   }));
@@ -41,13 +46,13 @@ function setupMocks(
     createApp: mockCreateApp,
   }));
   vi.doMock("@/server/gateway/discord.gateway", () => ({
-    // biome-ignore lint/complexity/useArrowFunction: constructor mock requires function
+    // biome-ignore lint/complexity/useArrowFunction: constructor mock requires function expression
     DiscordGateway: vi.fn().mockImplementation(function () {
       return { start: mockStart, stop: mockStop };
     }),
   }));
   vi.doMock("@/infrastructure/redis/redis.client", () => ({
-    // biome-ignore lint/complexity/useArrowFunction: constructor mock requires function
+    // biome-ignore lint/complexity/useArrowFunction: constructor mock requires function expression
     RedisClient: vi.fn().mockImplementation(function () {
       return {
         connect: mockRedisConnect,
@@ -55,8 +60,17 @@ function setupMocks(
       };
     }),
   }));
+  vi.doMock("@/infrastructure/discord/discord-api.client", () => ({
+    // biome-ignore lint/complexity/useArrowFunction: constructor mock requires function expression
+    DiscordApiClient: vi.fn().mockImplementation(function () {
+      return {
+        registerGuildCommands: mockRegisterGuildCommands,
+        sendMessage: vi.fn(),
+      };
+    }),
+  }));
   vi.doMock("@/ai/client/codex.client", () => ({
-    // biome-ignore lint/complexity/useArrowFunction: constructor mock requires function
+    // biome-ignore lint/complexity/useArrowFunction: constructor mock requires function expression
     CodexClient: vi.fn().mockImplementation(function () {
       return {};
     }),
@@ -222,18 +236,158 @@ describe("bootstrap error", () => {
     expect(() => bootstrap()).toThrow("config error");
   });
 
-  it("throws when OPENAI_API_KEY is not set", async () => {
+  it("throws when OPENAI_API_KEY and CODEX_API_KEY are not set", async () => {
     setupMocks(
       {
         bot: { defaultModel: "codex-mini", maxTokens: 4096, timeoutMs: 30000 },
         server: { port: 3000 },
         logging: { level: "info" },
       },
-      { OPENAI_API_KEY: undefined },
+      { OPENAI_API_KEY: undefined, CODEX_API_KEY: undefined },
     );
 
     const { bootstrap } = await import("@/app/bootstrap");
 
-    expect(() => bootstrap()).toThrow("OPENAI_API_KEY is required");
+    expect(() => bootstrap()).toThrow(
+      "CODEX_API_KEY or OPENAI_API_KEY is required",
+    );
+  });
+});
+
+describe("bootstrap API key selection", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.restoreAllMocks();
+    mockCreateApp.mockClear();
+    mockCreateApp.mockReturnValue({ fetch: vi.fn() });
+  });
+
+  it("prefers CODEX_API_KEY over OPENAI_API_KEY", async () => {
+    setupMocks(
+      {
+        bot: { defaultModel: "codex-mini", maxTokens: 4096, timeoutMs: 30000 },
+        server: { port: 3000 },
+        logging: { level: "info" },
+      },
+      { CODEX_API_KEY: "codex-key", OPENAI_API_KEY: "openai-key" },
+    );
+
+    const { CodexClient } = await import("@/ai/client/codex.client");
+    const { bootstrap } = await import("@/app/bootstrap");
+
+    bootstrap();
+
+    expect(CodexClient).toHaveBeenCalledWith(
+      "codex-key",
+      expect.objectContaining({ baseUrl: undefined, model: undefined }),
+    );
+  });
+
+  it("falls back to OPENAI_API_KEY when CODEX_API_KEY is not set", async () => {
+    setupMocks(
+      {
+        bot: { defaultModel: "codex-mini", maxTokens: 4096, timeoutMs: 30000 },
+        server: { port: 3000 },
+        logging: { level: "info" },
+      },
+      { CODEX_API_KEY: undefined, OPENAI_API_KEY: "openai-key" },
+    );
+
+    const { CodexClient } = await import("@/ai/client/codex.client");
+    const { bootstrap } = await import("@/app/bootstrap");
+
+    bootstrap();
+
+    expect(CodexClient).toHaveBeenCalledWith(
+      "openai-key",
+      expect.objectContaining({ baseUrl: undefined, model: undefined }),
+    );
+  });
+});
+
+describe("bootstrap CodexClient options", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.restoreAllMocks();
+    mockCreateApp.mockClear();
+    mockCreateApp.mockReturnValue({ fetch: vi.fn() });
+  });
+
+  it("passes CODEX_BASE_URL and CODEX_MODEL to CodexClient", async () => {
+    setupMocks(
+      {
+        bot: { defaultModel: "codex-mini", maxTokens: 4096, timeoutMs: 30000 },
+        server: { port: 3000 },
+        logging: { level: "info" },
+      },
+      {
+        CODEX_BASE_URL: "https://custom.api",
+        CODEX_MODEL: "custom-model",
+      },
+    );
+
+    const { CodexClient } = await import("@/ai/client/codex.client");
+    const { bootstrap } = await import("@/app/bootstrap");
+
+    bootstrap();
+
+    expect(CodexClient).toHaveBeenCalledWith(
+      "test-key",
+      expect.objectContaining({
+        baseUrl: "https://custom.api",
+        model: "custom-model",
+      }),
+    );
+  });
+});
+
+describe("bootstrap guild command registration", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.restoreAllMocks();
+    mockCreateApp.mockClear();
+    mockCreateApp.mockReturnValue({ fetch: vi.fn() });
+    mockRegisterGuildCommands.mockClear();
+  });
+
+  it("calls registerGuildCommands when DISCORD_GUILD_ID is set", async () => {
+    setupMocks(
+      {
+        bot: { defaultModel: "codex-mini", maxTokens: 4096, timeoutMs: 30000 },
+        server: { port: 3000 },
+        logging: { level: "info" },
+      },
+      { DISCORD_GUILD_ID: "guild-123" },
+    );
+
+    const { bootstrap } = await import("@/app/bootstrap");
+
+    bootstrap();
+
+    expect(mockRegisterGuildCommands).toHaveBeenCalledWith(
+      "test-app-id",
+      "guild-123",
+      expect.arrayContaining([
+        expect.objectContaining({ name: "ping" }),
+        expect.objectContaining({ name: "chat" }),
+      ]),
+    );
+  });
+
+  it("does not call registerGuildCommands when DISCORD_GUILD_ID is not set", async () => {
+    setupMocks(
+      {
+        bot: { defaultModel: "codex-mini", maxTokens: 4096, timeoutMs: 30000 },
+        server: { port: 3000 },
+        logging: { level: "info" },
+      },
+      { DISCORD_GUILD_ID: undefined },
+    );
+
+    const { bootstrap } = await import("@/app/bootstrap");
+
+    bootstrap();
+
+    expect(mockRegisterGuildCommands).not.toHaveBeenCalled();
   });
 });

--- a/src/app/bootstrap.ts
+++ b/src/app/bootstrap.ts
@@ -13,49 +13,68 @@ import { DiscordGateway } from "@/server/gateway/discord.gateway";
 import { createApp } from "@/server/hono";
 import { createLogger, getLogger } from "@/shared/utils/logger";
 
-function initDiscord(aiService: AIService) {
+function createAIService(): { aiService: AIService; redis: RedisClient } {
+  const codexApiKey = env.CODEX_API_KEY ?? env.OPENAI_API_KEY;
+  if (!codexApiKey) {
+    throw new Error("CODEX_API_KEY or OPENAI_API_KEY is required");
+  }
+  const codex = new CodexClient(codexApiKey, {
+    baseUrl: env.CODEX_BASE_URL,
+    model: env.CODEX_MODEL,
+  });
+  const redisUrl = env.REDIS_URL ?? "redis://localhost:6379";
+  const redis = new RedisClient(redisUrl);
+  redis.connect().catch((err) => {
+    getLogger().warn({ err: String(err) }, "Redis connection failed");
+  });
+  return { aiService: new AIService(codex, redis), redis };
+}
+
+function createDiscordDeps(aiService: AIService) {
   const botToken = env.DISCORD_BOT_TOKEN;
   const applicationId = env.DISCORD_APPLICATION_ID;
-  if (!botToken) {
-    throw new Error("DISCORD_BOT_TOKEN is required");
-  }
-  if (!applicationId) {
-    throw new Error("DISCORD_APPLICATION_ID is required");
-  }
+  if (!botToken) throw new Error("DISCORD_BOT_TOKEN is required");
+  if (!applicationId) throw new Error("DISCORD_APPLICATION_ID is required");
+
   const discordApiClient = new DiscordApiClient(botToken);
+  const chatCommand = new ChatCommand(
+    aiService,
+    discordApiClient,
+    applicationId,
+  );
+  const commands = [new PingCommand(), chatCommand];
   const messageHandler = new MessageHandler(
     aiService,
     discordApiClient,
     applicationId,
   );
-  return { botToken, applicationId, discordApiClient, messageHandler };
+  const router = new Router(commands);
+  const interactionHandler = new InteractionHandler(router);
+
+  const guildId = env.DISCORD_GUILD_ID;
+  if (guildId) {
+    discordApiClient
+      .registerGuildCommands(applicationId, guildId, commands)
+      .catch((err) => {
+        getLogger().error(
+          { err: String(err) },
+          "Guild command registration failed",
+        );
+      });
+  }
+
+  return { botToken, interactionHandler, messageHandler };
 }
 
 export function bootstrap() {
   const config = loadConfig();
-
   createLogger(config.logging);
-
   const log = getLogger();
   log.debug({ config }, "Config loaded");
 
-  const redis = new RedisClient(config.redis?.url ?? "redis://localhost:6379");
-  redis.connect().catch((err) => {
-    log.warn({ err: String(err) }, "Redis connection failed");
-  });
-
-  const apiKey = env.OPENAI_API_KEY;
-  if (!apiKey) {
-    throw new Error("OPENAI_API_KEY is required");
-  }
-  const codex = new CodexClient(apiKey);
-  const aiService = new AIService(codex, redis);
-
-  const commands = [new PingCommand(), new ChatCommand(aiService)];
-  const router = new Router(commands);
-  const interactionHandler = new InteractionHandler(router);
-
-  const { botToken, messageHandler } = initDiscord(aiService);
+  const { aiService, redis } = createAIService();
+  const { botToken, interactionHandler, messageHandler } =
+    createDiscordDeps(aiService);
 
   const app = createApp({ interactionHandler, messageHandler, botToken });
 

--- a/src/app/config/config.yaml
+++ b/src/app/config/config.yaml
@@ -7,7 +7,7 @@ server:
   port: 3000
 
 logging:
-  level: "info"
+  level: "debug"
 
 redis:
   url: "redis://localhost:6379"

--- a/src/app/config/config.yaml
+++ b/src/app/config/config.yaml
@@ -7,7 +7,7 @@ server:
   port: 3000
 
 logging:
-  level: "debug"
+  level: "info"
 
 redis:
   url: "redis://localhost:6379"

--- a/src/app/config/env.test.ts
+++ b/src/app/config/env.test.ts
@@ -6,7 +6,7 @@ function setupEnv() {
   beforeEach(() => {
     vi.resetModules();
     vi.restoreAllMocks();
-    process.env = { ...originalEnv };
+    process.env = { ...originalEnv, NODE_ENV: "test" };
   });
 }
 
@@ -168,5 +168,89 @@ describe("env DISCORD_APPLICATION_ID", () => {
     const { env } = await import("@/app/config/env");
 
     expect(env.DISCORD_APPLICATION_ID).toBeUndefined();
+  });
+});
+
+describe("env DISCORD_GUILD_ID", () => {
+  setupEnv();
+
+  it("parses DISCORD_GUILD_ID when set", async () => {
+    process.env.NODE_ENV = "test";
+    process.env.DISCORD_GUILD_ID = "guild-123";
+
+    const { env } = await import("@/app/config/env");
+
+    expect(env.DISCORD_GUILD_ID).toBe("guild-123");
+  });
+
+  it("returns undefined when not set", async () => {
+    delete process.env.DISCORD_GUILD_ID;
+
+    const { env } = await import("@/app/config/env");
+
+    expect(env.DISCORD_GUILD_ID).toBeUndefined();
+  });
+});
+
+describe("env CODEX_BASE_URL", () => {
+  setupEnv();
+
+  it("parses CODEX_BASE_URL when set", async () => {
+    process.env.NODE_ENV = "test";
+    process.env.CODEX_BASE_URL = "https://api.example.com";
+
+    const { env } = await import("@/app/config/env");
+
+    expect(env.CODEX_BASE_URL).toBe("https://api.example.com");
+  });
+
+  it("returns undefined when not set", async () => {
+    delete process.env.CODEX_BASE_URL;
+
+    const { env } = await import("@/app/config/env");
+
+    expect(env.CODEX_BASE_URL).toBeUndefined();
+  });
+});
+
+describe("env CODEX_API_KEY", () => {
+  setupEnv();
+
+  it("parses CODEX_API_KEY when set", async () => {
+    process.env.NODE_ENV = "test";
+    process.env.CODEX_API_KEY = "codex-key-123";
+
+    const { env } = await import("@/app/config/env");
+
+    expect(env.CODEX_API_KEY).toBe("codex-key-123");
+  });
+
+  it("returns undefined when not set", async () => {
+    delete process.env.CODEX_API_KEY;
+
+    const { env } = await import("@/app/config/env");
+
+    expect(env.CODEX_API_KEY).toBeUndefined();
+  });
+});
+
+describe("env CODEX_MODEL", () => {
+  setupEnv();
+
+  it("parses CODEX_MODEL when set", async () => {
+    process.env.NODE_ENV = "test";
+    process.env.CODEX_MODEL = "codex-mini";
+
+    const { env } = await import("@/app/config/env");
+
+    expect(env.CODEX_MODEL).toBe("codex-mini");
+  });
+
+  it("returns undefined when not set", async () => {
+    delete process.env.CODEX_MODEL;
+
+    const { env } = await import("@/app/config/env");
+
+    expect(env.CODEX_MODEL).toBeUndefined();
   });
 });

--- a/src/app/config/env.ts
+++ b/src/app/config/env.ts
@@ -9,6 +9,10 @@ const envSchema = z.object({
   DISCORD_PUBLIC_KEY: z.string().optional(),
   DISCORD_BOT_TOKEN: z.string().optional(),
   DISCORD_APPLICATION_ID: z.string().optional(),
+  DISCORD_GUILD_ID: z.string().optional(),
+  CODEX_BASE_URL: z.string().optional(),
+  CODEX_API_KEY: z.string().optional(),
+  CODEX_MODEL: z.string().optional(),
 });
 
 export const env = envSchema.parse(process.env);

--- a/src/bot/commands/ai/chat.command.test.ts
+++ b/src/bot/commands/ai/chat.command.test.ts
@@ -1,13 +1,18 @@
 import { MessageFlags } from "discord-api-types/v10";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { AIService } from "@/ai/services/ai.service";
+import type { DiscordApiClient } from "@/infrastructure/discord/discord-api.client";
 import type { DomainInteraction } from "@/sdk/discord/types/domain";
 import { ExternalServiceError } from "@/shared/types/errors";
 import { err, ok } from "@/shared/types/result";
 import { ChatCommand } from "./chat.command";
 
 vi.mock("@/shared/utils/logger", () => ({
-  getLogger: vi.fn().mockReturnValue({ info: vi.fn(), debug: vi.fn() }),
+  getLogger: vi.fn().mockReturnValue({
+    info: vi.fn(),
+    debug: vi.fn(),
+    error: vi.fn(),
+  }),
 }));
 
 function createInteraction(
@@ -20,7 +25,7 @@ function createInteraction(
     userId: "user-1",
     commandName: "chat",
     options: { message: "Hello" },
-    raw: {},
+    raw: { token: "test-token" },
     ...overrides,
   };
 }
@@ -29,146 +34,269 @@ function createMockAIService(): AIService {
   return {
     chat: vi.fn(),
     resetConversation: vi.fn(),
+    linkThreadChannel: vi.fn().mockResolvedValue(undefined),
   } as unknown as AIService;
 }
 
-describe("ChatCommand properties", () => {
-  let aiService: AIService;
+function createMockDiscordApiClient(): DiscordApiClient {
+  return {
+    editInteractionResponse: vi.fn().mockResolvedValue("msg-123"),
+    createThreadFromMessage: vi.fn().mockResolvedValue("thread-999"),
+    sendMessage: vi.fn().mockResolvedValue(true),
+    registerGuildCommands: vi.fn().mockResolvedValue(undefined),
+    isThreadChannel: vi.fn().mockResolvedValue(false),
+  } as unknown as DiscordApiClient;
+}
 
-  beforeEach(() => {
-    aiService = createMockAIService();
+const APPLICATION_ID = "test-app-id";
+
+function flushPromises(): Promise<void> {
+  return new Promise((resolve) => setImmediate(resolve));
+}
+
+describe("ChatCommand properties", () => {
+  it("has name 'chat'", () => {
+    const command = new ChatCommand(
+      createMockAIService(),
+      createMockDiscordApiClient(),
+      APPLICATION_ID,
+    );
+    expect(command.name).toBe("chat");
   });
 
-  it("has name 'chat'", () => {
-    const command = new ChatCommand(aiService);
-    expect(command.name).toBe("chat");
+  it("has definition with description and options", () => {
+    const command = new ChatCommand(
+      createMockAIService(),
+      createMockDiscordApiClient(),
+      APPLICATION_ID,
+    );
+    expect(command.definition).toEqual({
+      description: "AIとチャット",
+      options: [
+        {
+          name: "message",
+          // biome-ignore lint/security/noSecrets: static Japanese UI text, not a secret
+          description: "AIに送信するメッセージ",
+          type: 3,
+          required: true,
+        },
+      ],
+    });
   });
 });
 
-describe("ChatCommand message extraction", () => {
+describe("ChatCommand deferred response", () => {
   let aiService: AIService;
+  let discordApiClient: DiscordApiClient;
 
   beforeEach(() => {
     aiService = createMockAIService();
+    discordApiClient = createMockDiscordApiClient();
   });
 
-  it("extracts message option from interaction", async () => {
-    const command = new ChatCommand(aiService);
+  it("returns deferred response immediately", async () => {
     (aiService.chat as ReturnType<typeof vi.fn>).mockResolvedValue(
       ok("AI response"),
+    );
+    const command = new ChatCommand(
+      aiService,
+      discordApiClient,
+      APPLICATION_ID,
+    );
+
+    const response = await command.execute(createInteraction());
+
+    expect(response.type).toBe(5);
+  });
+
+  it("returns error message when interaction has no token", async () => {
+    const command = new ChatCommand(
+      aiService,
+      discordApiClient,
+      APPLICATION_ID,
+    );
+
+    const response = await command.execute(createInteraction({ raw: {} }));
+
+    expect(response.type).toBe(4);
+    expect(response.data?.flags).toBe(MessageFlags.Ephemeral);
+  });
+});
+
+describe("ChatCommand background input forwarding", () => {
+  let aiService: AIService;
+  let discordApiClient: DiscordApiClient;
+
+  beforeEach(() => {
+    aiService = createMockAIService();
+    discordApiClient = createMockDiscordApiClient();
+  });
+
+  it("extracts message option and passes to AIService", async () => {
+    (aiService.chat as ReturnType<typeof vi.fn>).mockResolvedValue(
+      ok("AI response"),
+    );
+    const command = new ChatCommand(
+      aiService,
+      discordApiClient,
+      APPLICATION_ID,
     );
 
     await command.execute(
       createInteraction({ options: { message: "Hello AI" } }),
     );
+    await flushPromises();
 
     expect(aiService.chat).toHaveBeenCalledWith("channel-1", "Hello AI");
   });
 
-  it("falls back to empty string when message option is missing", async () => {
-    const command = new ChatCommand(aiService);
-    (aiService.chat as ReturnType<typeof vi.fn>).mockResolvedValue(
-      ok("AI response"),
-    );
-
-    await command.execute(createInteraction({ options: {} }));
-
-    expect(aiService.chat).toHaveBeenCalledWith("channel-1", "");
-  });
-
-  it("falls back to empty string when options is undefined", async () => {
-    const command = new ChatCommand(aiService);
-    (aiService.chat as ReturnType<typeof vi.fn>).mockResolvedValue(
-      ok("AI response"),
-    );
-
-    await command.execute(createInteraction({ options: undefined }));
-
-    expect(aiService.chat).toHaveBeenCalledWith("channel-1", "");
-  });
-
-  it("handles empty message string", async () => {
-    const command = new ChatCommand(aiService);
-    (aiService.chat as ReturnType<typeof vi.fn>).mockResolvedValue(
-      ok("AI response"),
-    );
-
-    await command.execute(createInteraction({ options: { message: "" } }));
-
-    expect(aiService.chat).toHaveBeenCalledWith("channel-1", "");
-  });
-});
-
-describe("ChatCommand channelId forwarding", () => {
-  let aiService: AIService;
-
-  beforeEach(() => {
-    aiService = createMockAIService();
-  });
-
   it("passes channelId to AIService", async () => {
-    const command = new ChatCommand(aiService);
     (aiService.chat as ReturnType<typeof vi.fn>).mockResolvedValue(
       ok("AI response"),
+    );
+    const command = new ChatCommand(
+      aiService,
+      discordApiClient,
+      APPLICATION_ID,
     );
 
     await command.execute(createInteraction({ channelId: "ch-999" }));
+    await flushPromises();
 
     expect(aiService.chat).toHaveBeenCalledWith("ch-999", expect.any(String));
   });
 });
 
-describe("ChatCommand success response", () => {
+describe("ChatCommand thread creation flow", () => {
   let aiService: AIService;
+  let discordApiClient: DiscordApiClient;
 
   beforeEach(() => {
     aiService = createMockAIService();
+    discordApiClient = createMockDiscordApiClient();
   });
 
-  it("returns message response with AI result on success", async () => {
-    const command = new ChatCommand(aiService);
+  it("edits response with user message then creates thread", async () => {
     (aiService.chat as ReturnType<typeof vi.fn>).mockResolvedValue(
       ok("AI response"),
     );
-
-    const response = await command.execute(createInteraction());
-
-    expect(response.type).toBe(4);
-    expect(response.data?.content).toBe("AI response");
-  });
-
-  it("returns non-ephemeral response on success", async () => {
-    const command = new ChatCommand(aiService);
-    (aiService.chat as ReturnType<typeof vi.fn>).mockResolvedValue(
-      ok("AI response"),
+    const command = new ChatCommand(
+      aiService,
+      discordApiClient,
+      APPLICATION_ID,
     );
 
-    const response = await command.execute(createInteraction());
+    await command.execute(createInteraction());
+    await flushPromises();
 
-    expect(response.data?.flags).toBeUndefined();
+    expect(discordApiClient.editInteractionResponse).toHaveBeenCalledWith(
+      APPLICATION_ID,
+      "test-token",
+      "> Hello",
+    );
+    expect(discordApiClient.createThreadFromMessage).toHaveBeenCalledWith(
+      "channel-1",
+      "msg-123",
+      "Hello",
+    );
+    expect(discordApiClient.sendMessage).toHaveBeenCalledWith(
+      "thread-999",
+      "AI response",
+    );
   });
 });
 
-describe("ChatCommand error response", () => {
+describe("ChatCommand thread fallback", () => {
   let aiService: AIService;
+  let discordApiClient: DiscordApiClient;
 
   beforeEach(() => {
     aiService = createMockAIService();
+    discordApiClient = createMockDiscordApiClient();
   });
 
-  it("returns ephemeral error when AIService fails", async () => {
-    const command = new ChatCommand(aiService);
+  it("sends AI response in channel when thread creation fails", async () => {
+    (aiService.chat as ReturnType<typeof vi.fn>).mockResolvedValue(
+      ok("AI response"),
+    );
+    (
+      discordApiClient.createThreadFromMessage as ReturnType<typeof vi.fn>
+    ).mockResolvedValue(null);
+    const command = new ChatCommand(
+      aiService,
+      discordApiClient,
+      APPLICATION_ID,
+    );
+
+    await command.execute(createInteraction());
+    await flushPromises();
+
+    expect(discordApiClient.sendMessage).toHaveBeenCalledWith(
+      "channel-1",
+      "AI response",
+    );
+  });
+});
+
+describe("ChatCommand error in thread", () => {
+  let aiService: AIService;
+  let discordApiClient: DiscordApiClient;
+
+  beforeEach(() => {
+    aiService = createMockAIService();
+    discordApiClient = createMockDiscordApiClient();
+  });
+
+  it("sends error in thread when AIService fails", async () => {
     (aiService.chat as ReturnType<typeof vi.fn>).mockResolvedValue(
       err(new ExternalServiceError("Codex", "timeout")),
     );
+    const command = new ChatCommand(
+      aiService,
+      discordApiClient,
+      APPLICATION_ID,
+    );
 
-    const response = await command.execute(createInteraction());
+    await command.execute(createInteraction());
+    await flushPromises();
 
-    expect(response.type).toBe(4);
-    expect(response.data?.content).toBe(
+    expect(discordApiClient.sendMessage).toHaveBeenCalledWith(
+      "thread-999",
       // biome-ignore lint/security/noSecrets: Japanese test assertion, not a secret
       "エラーが発生しました。しばらくしてからお試しください。",
     );
-    expect(response.data?.flags).toBe(MessageFlags.Ephemeral);
+  });
+});
+
+describe("ChatCommand inside existing thread", () => {
+  let aiService: AIService;
+  let discordApiClient: DiscordApiClient;
+
+  beforeEach(() => {
+    aiService = createMockAIService();
+    discordApiClient = createMockDiscordApiClient();
+    (
+      discordApiClient.isThreadChannel as ReturnType<typeof vi.fn>
+    ).mockResolvedValue(true);
+  });
+
+  it("skips thread creation and sends response directly", async () => {
+    (aiService.chat as ReturnType<typeof vi.fn>).mockResolvedValue(
+      ok("AI response"),
+    );
+    const command = new ChatCommand(
+      aiService,
+      discordApiClient,
+      APPLICATION_ID,
+    );
+
+    await command.execute(createInteraction());
+    await flushPromises();
+
+    expect(discordApiClient.createThreadFromMessage).not.toHaveBeenCalled();
+    expect(discordApiClient.sendMessage).toHaveBeenCalledWith(
+      "channel-1",
+      "AI response",
+    );
   });
 });

--- a/src/bot/commands/ai/chat.command.ts
+++ b/src/bot/commands/ai/chat.command.ts
@@ -80,7 +80,7 @@ export class ChatCommand implements Command {
       const threadId = await this.discordApiClient.createThreadFromMessage(
         channelId,
         messageId,
-        userMessage,
+        userMessage.slice(0, 100),
       );
       if (threadId) targetChannelId = threadId;
     }

--- a/src/bot/commands/ai/chat.command.ts
+++ b/src/bot/commands/ai/chat.command.ts
@@ -1,31 +1,114 @@
 import type { AIService } from "@/ai/services/ai.service";
-import { message } from "@/sdk/discord/adapter/response.adapter";
+import type { DiscordApiClient } from "@/infrastructure/discord/discord-api.client";
+import { deferred, message } from "@/sdk/discord/adapter/response.adapter";
 import type {
   DomainInteraction,
   DomainResponse,
 } from "@/sdk/discord/types/domain";
+import { getLogger } from "@/shared/utils/logger";
 import type { Command } from "../command.interface";
 
 export class ChatCommand implements Command {
   readonly name = "chat";
+  readonly definition = {
+    description: "AIとチャット",
+    options: [
+      {
+        name: "message",
+        // biome-ignore lint/security/noSecrets: static Japanese UI text, not a secret
+        description: "AIに送信するメッセージ",
+        type: 3 as const,
+        required: true,
+      },
+    ],
+  };
 
-  constructor(private aiService: AIService) {}
+  constructor(
+    private aiService: AIService,
+    private discordApiClient: DiscordApiClient,
+    private applicationId: string,
+  ) {}
 
-  async execute(interaction: DomainInteraction): Promise<DomainResponse> {
+  execute(interaction: DomainInteraction): Promise<DomainResponse> {
+    const log = getLogger();
     const userMessage = (interaction.options?.message as string) ?? "";
-    const result = await this.aiService.chat(
-      interaction.channelId,
-      userMessage,
+
+    log.debug(
+      { channelId: interaction.channelId, userMessage },
+      "ChatCommand executing",
     );
 
-    if (!result.ok) {
-      return message(
-        // biome-ignore lint/security/noSecrets: static Japanese error message, not a secret
-        "エラーが発生しました。しばらくしてからお試しください。",
-        true,
+    const token = (interaction.raw as { token?: string })?.token;
+    if (!token) {
+      log.error("Interaction has no token, cannot defer response");
+      return Promise.resolve(
+        message(
+          // biome-ignore lint/security/noSecrets: static Japanese error message, not a secret
+          "エラーが発生しました。しばらくしてからお試しください。",
+          true,
+        ),
       );
     }
 
-    return message(result.value);
+    this.processInBackground(interaction.channelId, userMessage, token).catch(
+      (err) => {
+        log.error({ err: String(err) }, "Background processing error");
+      },
+    );
+
+    return Promise.resolve(deferred());
+  }
+
+  private async processInBackground(
+    channelId: string,
+    userMessage: string,
+    interactionToken: string,
+  ): Promise<void> {
+    const log = getLogger();
+
+    const inThread = await this.isThreadChannel(channelId);
+    const responseContent = inThread ? userMessage : `> ${userMessage}`;
+    const messageId = await this.discordApiClient.editInteractionResponse(
+      this.applicationId,
+      interactionToken,
+      responseContent,
+    );
+    if (!messageId) return;
+
+    let targetChannelId = channelId;
+    if (!inThread && messageId) {
+      const threadId = await this.discordApiClient.createThreadFromMessage(
+        channelId,
+        messageId,
+        userMessage,
+      );
+      if (threadId) targetChannelId = threadId;
+    }
+
+    const result = await this.aiService.chat(channelId, userMessage);
+
+    if (targetChannelId !== channelId) {
+      await this.aiService.linkThreadChannel(channelId, targetChannelId);
+    }
+
+    if (!result.ok) {
+      log.error(
+        { error: result.error.message, channelId },
+        "AI service returned error",
+      );
+      await this.discordApiClient.sendMessage(
+        targetChannelId,
+        // biome-ignore lint/security/noSecrets: static Japanese error message, not a secret
+        "エラーが発生しました。しばらくしてからお試しください。",
+      );
+      return;
+    }
+
+    await this.discordApiClient.sendMessage(targetChannelId, result.value);
+  }
+
+  private async isThreadChannel(channelId: string): Promise<boolean> {
+    const result = await this.discordApiClient.isThreadChannel(channelId);
+    return result;
   }
 }

--- a/src/bot/commands/command.interface.ts
+++ b/src/bot/commands/command.interface.ts
@@ -3,7 +3,20 @@ import type {
   DomainResponse,
 } from "@/sdk/discord/types/domain";
 
+export interface CommandOption {
+  name: string;
+  description: string;
+  type: number;
+  required?: boolean;
+}
+
+export interface CommandDefinition {
+  description: string;
+  options?: CommandOption[];
+}
+
 export interface Command {
   readonly name: string;
+  readonly definition?: CommandDefinition;
   execute(interaction: DomainInteraction): Promise<DomainResponse>;
 }

--- a/src/bot/commands/utility/ping.command.test.ts
+++ b/src/bot/commands/utility/ping.command.test.ts
@@ -23,6 +23,12 @@ describe("PingCommand", () => {
     expect(command.name).toBe("ping");
   });
 
+  it("has definition with description", () => {
+    expect(command.definition).toEqual({
+      description: "Ping-Pong",
+    });
+  });
+
   it("returns message with content 'Pong!'", async () => {
     const response = await command.execute(createInteraction());
 

--- a/src/bot/commands/utility/ping.command.ts
+++ b/src/bot/commands/utility/ping.command.ts
@@ -7,6 +7,9 @@ import type { Command } from "../command.interface";
 
 export class PingCommand implements Command {
   readonly name = "ping";
+  readonly definition = {
+    description: "Ping-Pong",
+  };
 
   execute(_interaction: DomainInteraction): Promise<DomainResponse> {
     return Promise.resolve(message("Pong!"));

--- a/src/bot/handlers/interaction.handler.test.ts
+++ b/src/bot/handlers/interaction.handler.test.ts
@@ -9,14 +9,12 @@ import { Router } from "../router";
 import { InteractionHandler } from "./interaction.handler";
 
 vi.mock("@/shared/utils/logger", () => ({
-  getLogger: vi
-    .fn()
-    .mockReturnValue({
-      info: vi.fn(),
-      warn: vi.fn(),
-      error: vi.fn(),
-      debug: vi.fn(),
-    }),
+  getLogger: vi.fn().mockReturnValue({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  }),
 }));
 
 function createInteraction(

--- a/src/bot/handlers/interaction.handler.test.ts
+++ b/src/bot/handlers/interaction.handler.test.ts
@@ -8,6 +8,17 @@ import type { Command } from "../commands/command.interface";
 import { Router } from "../router";
 import { InteractionHandler } from "./interaction.handler";
 
+vi.mock("@/shared/utils/logger", () => ({
+  getLogger: vi
+    .fn()
+    .mockReturnValue({
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+      debug: vi.fn(),
+    }),
+}));
+
 function createInteraction(
   overrides: Partial<DomainInteraction> = {},
 ): DomainInteraction {

--- a/src/bot/handlers/interaction.handler.ts
+++ b/src/bot/handlers/interaction.handler.ts
@@ -3,27 +3,42 @@ import type {
   DomainInteraction,
   DomainResponse,
 } from "@/sdk/discord/types/domain";
+import { getLogger } from "@/shared/utils/logger";
 import type { Router } from "../router";
 
 export class InteractionHandler {
   constructor(private router: Router) {}
 
   async handle(interaction: DomainInteraction): Promise<DomainResponse> {
+    const log = getLogger();
+
     if (interaction.type === "ping") {
       return pong();
     }
 
+    log.debug(
+      { type: interaction.type, commandName: interaction.commandName },
+      "Handling interaction",
+    );
+
     const command = this.router.resolve(interaction);
     if (!command) {
+      log.warn({ commandName: interaction.commandName }, "Unknown command");
       // biome-ignore lint/security/noSecrets: static Japanese error message, not a secret
       return message("不明なコマンドです", true);
     }
 
     try {
-      return await command.execute(interaction);
-    } catch {
-      // biome-ignore lint/security/noSecrets: static Japanese error message, not a secret
+      const result = await command.execute(interaction);
+      log.debug({ commandName: command.name }, "Command executed successfully");
+      return result;
+    } catch (err) {
+      log.error(
+        { err: String(err), commandName: command.name },
+        "Command execution error",
+      );
       return message(
+        // biome-ignore lint/security/noSecrets: static Japanese error message, not a secret
         "エラーが発生しました。しばらくしてからお試しください。",
         true,
       );

--- a/src/bot/handlers/message.handler.test.ts
+++ b/src/bot/handlers/message.handler.test.ts
@@ -19,14 +19,22 @@ vi.mock("@/shared/utils/logger", () => ({
 
 const mockChat = vi.fn();
 const mockSendMessage = vi.fn();
+const mockCreateThreadFromMessage = vi.fn();
+const mockIsThreadChannel = vi.fn();
+const mockLinkThreadChannel = vi.fn();
 
 vi.mock("@/ai/services/ai.service", () => ({
-  AIService: vi.fn().mockImplementation(() => ({ chat: mockChat })),
+  AIService: vi.fn().mockImplementation(() => ({
+    chat: mockChat,
+    linkThreadChannel: mockLinkThreadChannel,
+  })),
 }));
 
 vi.mock("@/infrastructure/discord/discord-api.client", () => ({
   DiscordApiClient: vi.fn().mockImplementation(() => ({
     sendMessage: mockSendMessage,
+    createThreadFromMessage: mockCreateThreadFromMessage,
+    isThreadChannel: mockIsThreadChannel,
   })),
 }));
 
@@ -49,29 +57,81 @@ function makeMentionEvent(
   };
 }
 
-describe("MessageHandler handleGatewayEvent - success", () => {
+function createMockDeps() {
+  const aiService = {
+    chat: mockChat,
+    linkThreadChannel: mockLinkThreadChannel,
+  } as unknown as AIService;
+  const discordApiClient = {
+    sendMessage: mockSendMessage,
+    createThreadFromMessage: mockCreateThreadFromMessage,
+    isThreadChannel: mockIsThreadChannel,
+  } as unknown as DiscordApiClient;
+  return { aiService, discordApiClient };
+}
+
+describe("MessageHandler thread creation", () => {
   let handler: InstanceType<typeof MessageHandler>;
 
   beforeEach(() => {
     vi.clearAllMocks();
-    const aiService = { chat: mockChat } as unknown as AIService;
-    const discordApiClient = {
-      sendMessage: mockSendMessage,
-    } as unknown as DiscordApiClient;
+    const { aiService, discordApiClient } = createMockDeps();
     handler = new MessageHandler(aiService, discordApiClient, "app-id");
   });
 
-  it("processes @mention message and sends AI response", async () => {
+  it("creates thread and sends response in thread", async () => {
     mockChat.mockResolvedValue({ ok: true, value: "AI response here" });
+    mockIsThreadChannel.mockResolvedValue(false);
+    mockCreateThreadFromMessage.mockResolvedValue("thread-1");
 
     await handler.handleGatewayEvent(makeMentionEvent());
 
-    expect(mockChat).toHaveBeenCalledWith("ch-1", "hello");
-    expect(mockSendMessage).toHaveBeenCalledWith("ch-1", "AI response here");
+    expect(mockCreateThreadFromMessage).toHaveBeenCalledWith(
+      "ch-1",
+      "msg-1",
+      "hello",
+    );
+    expect(mockSendMessage).toHaveBeenCalledWith(
+      "thread-1",
+      "AI response here",
+    );
+    expect(mockLinkThreadChannel).toHaveBeenCalledWith("ch-1", "thread-1");
+  });
+
+  it("sends response in channel when thread creation fails", async () => {
+    mockChat.mockResolvedValue({ ok: true, value: "AI response" });
+    mockIsThreadChannel.mockResolvedValue(false);
+    mockCreateThreadFromMessage.mockResolvedValue(null);
+
+    await handler.handleGatewayEvent(makeMentionEvent());
+
+    expect(mockSendMessage).toHaveBeenCalledWith("ch-1", "AI response");
+    expect(mockLinkThreadChannel).not.toHaveBeenCalled();
+  });
+});
+
+describe("MessageHandler in existing thread", () => {
+  let handler: InstanceType<typeof MessageHandler>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    const { aiService, discordApiClient } = createMockDeps();
+    handler = new MessageHandler(aiService, discordApiClient, "app-id");
+  });
+
+  it("sends response in channel when already in thread", async () => {
+    mockChat.mockResolvedValue({ ok: true, value: "AI response" });
+    mockIsThreadChannel.mockResolvedValue(true);
+
+    await handler.handleGatewayEvent(makeMentionEvent());
+
+    expect(mockCreateThreadFromMessage).not.toHaveBeenCalled();
+    expect(mockSendMessage).toHaveBeenCalledWith("ch-1", "AI response");
   });
 
   it("strips nickname format mention from content", async () => {
     mockChat.mockResolvedValue({ ok: true, value: "response" });
+    mockIsThreadChannel.mockResolvedValue(true);
 
     const event = makeMentionEvent({
       content: "<@!app-id> how are you?",
@@ -83,15 +143,54 @@ describe("MessageHandler handleGatewayEvent - success", () => {
   });
 });
 
-describe("MessageHandler handleGatewayEvent - filtering", () => {
+describe("MessageHandler logging", () => {
   let handler: InstanceType<typeof MessageHandler>;
 
   beforeEach(() => {
     vi.clearAllMocks();
-    const aiService = { chat: mockChat } as unknown as AIService;
-    const discordApiClient = {
-      sendMessage: mockSendMessage,
-    } as unknown as DiscordApiClient;
+    const { aiService, discordApiClient } = createMockDeps();
+    handler = new MessageHandler(aiService, discordApiClient, "app-id");
+  });
+
+  it("logs received mention message with user input", async () => {
+    mockChat.mockResolvedValue({ ok: true, value: "AI response" });
+    mockIsThreadChannel.mockResolvedValue(true);
+
+    await handler.handleGatewayEvent(makeMentionEvent());
+
+    expect(mockLogInfo).toHaveBeenCalledWith(
+      {
+        channelId: "ch-1",
+        userId: "user-1",
+        userMessage: "hello",
+      },
+      "Received mention message",
+    );
+  });
+
+  it("logs AI response when sent successfully", async () => {
+    mockChat.mockResolvedValue({ ok: true, value: "AI response here" });
+    mockIsThreadChannel.mockResolvedValue(true);
+
+    await handler.handleGatewayEvent(makeMentionEvent());
+
+    expect(mockLogInfo).toHaveBeenCalledWith(
+      {
+        channelId: "ch-1",
+        responseLength: 16,
+        responsePreview: "AI response here",
+      },
+      "Sending AI response",
+    );
+  });
+});
+
+describe("MessageHandler filtering", () => {
+  let handler: InstanceType<typeof MessageHandler>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    const { aiService, discordApiClient } = createMockDeps();
     handler = new MessageHandler(aiService, discordApiClient, "app-id");
   });
 
@@ -145,43 +244,45 @@ describe("MessageHandler handleGatewayEvent - filtering", () => {
   });
 });
 
-describe("MessageHandler handleGatewayEvent - errors", () => {
+describe("MessageHandler errors", () => {
   let handler: InstanceType<typeof MessageHandler>;
 
   beforeEach(() => {
     vi.clearAllMocks();
-    const aiService = { chat: mockChat } as unknown as AIService;
-    const discordApiClient = {
-      sendMessage: mockSendMessage,
-    } as unknown as DiscordApiClient;
+    const { aiService, discordApiClient } = createMockDeps();
     handler = new MessageHandler(aiService, discordApiClient, "app-id");
   });
 
-  it("logs error when AIService fails", async () => {
+  it("logs error and sends error message when AIService fails", async () => {
     mockChat.mockResolvedValue({
       ok: false,
       error: { message: "Codex error" },
     });
+    mockIsThreadChannel.mockResolvedValue(true);
 
     await handler.handleGatewayEvent(makeMentionEvent());
 
     expect(mockLogError).toHaveBeenCalledWith(
       { error: "Codex error", channelId: "ch-1" },
-      "AI service error in mention handler",
+      "AI service error",
     );
-    expect(mockSendMessage).not.toHaveBeenCalled();
+    expect(mockSendMessage).toHaveBeenCalledWith(
+      "ch-1",
+      // biome-ignore lint/security/noSecrets: Japanese test assertion, not a secret
+      "エラーが発生しました。しばらくしてからお試しください。",
+    );
   });
 
   it("logs error when sendMessage returns false", async () => {
     mockChat.mockResolvedValue({ ok: true, value: "AI response" });
+    mockIsThreadChannel.mockResolvedValue(true);
     mockSendMessage.mockResolvedValue(false);
 
     await handler.handleGatewayEvent(makeMentionEvent());
 
-    expect(mockSendMessage).toHaveBeenCalledWith("ch-1", "AI response");
     expect(mockLogError).toHaveBeenCalledWith(
       { channelId: "ch-1" },
-      "Failed to send AI response to Discord",
+      "Failed to send AI response",
     );
   });
 
@@ -191,7 +292,6 @@ describe("MessageHandler handleGatewayEvent - errors", () => {
       timestamp: Date.now(),
       data: {
         mentions: [{ id: "app-id", username: "testbot" }],
-        // missing required fields
       },
     };
 
@@ -199,7 +299,7 @@ describe("MessageHandler handleGatewayEvent - errors", () => {
 
     expect(mockLogWarn).toHaveBeenCalledWith(
       { error: expect.any(String) },
-      "Failed to extract message data from gateway event",
+      "Failed to extract message data",
     );
     expect(mockChat).not.toHaveBeenCalled();
   });

--- a/src/bot/handlers/message.handler.ts
+++ b/src/bot/handlers/message.handler.ts
@@ -106,7 +106,7 @@ export class MessageHandler {
     const threadId = await this.discordApiClient.createThreadFromMessage(
       message.channel_id,
       message.id,
-      threadName,
+      threadName.slice(0, 100),
     );
     return threadId ?? message.channel_id;
   }

--- a/src/bot/handlers/message.handler.ts
+++ b/src/bot/handlers/message.handler.ts
@@ -5,7 +5,10 @@ import {
   isMentionEvent,
   stripMentionFromContent,
 } from "@/sdk/discord/adapter/gateway-event.adapter";
-import type { GatewayEvent } from "@/sdk/discord/types/gateway";
+import type {
+  GatewayEvent,
+  GatewayMessageData,
+} from "@/sdk/discord/types/gateway";
 import { getLogger } from "@/shared/utils/logger";
 
 export class MessageHandler {
@@ -18,20 +21,40 @@ export class MessageHandler {
   async handleGatewayEvent(event: GatewayEvent): Promise<void> {
     const log = getLogger();
 
-    if (!isMentionEvent(event, this.applicationId)) return;
+    log.debug(
+      {
+        eventType: event.type,
+        hasMentions: Array.isArray(
+          (event.data as Record<string, unknown>)?.mentions,
+        ),
+      },
+      "MessageHandler received gateway event",
+    );
+
+    if (!isMentionEvent(event, this.applicationId)) {
+      log.debug({ eventType: event.type }, "Not a mention event, skipping");
+      return;
+    }
 
     const messageResult = extractMessageData(event);
     if (!messageResult.ok) {
       log.warn(
         { error: messageResult.error.message },
-        "Failed to extract message data from gateway event",
+        "Failed to extract message data",
       );
       return;
     }
 
-    const message = messageResult.value;
+    await this.processMessage(messageResult.value);
+  }
 
-    if (message.author.bot) return;
+  private async processMessage(message: GatewayMessageData): Promise<void> {
+    const log = getLogger();
+
+    if (message.author.bot) {
+      log.debug({ authorId: message.author.id }, "Author is a bot, skipping");
+      return;
+    }
 
     const userMessage = stripMentionFromContent(
       message.content,
@@ -46,25 +69,85 @@ export class MessageHandler {
       return;
     }
 
+    log.info(
+      {
+        channelId: message.channel_id,
+        userId: message.author.id,
+        userMessage,
+      },
+      "Received mention message",
+    );
+
+    const targetChannelId = await this.resolveTargetChannel(
+      message,
+      userMessage,
+    );
     const result = await this.aiService.chat(message.channel_id, userMessage);
+
+    if (targetChannelId !== message.channel_id) {
+      await this.aiService.linkThreadChannel(
+        message.channel_id,
+        targetChannelId,
+      );
+    }
+
+    await this.sendResult(result, targetChannelId, message.channel_id);
+  }
+
+  private async resolveTargetChannel(
+    message: GatewayMessageData,
+    threadName: string,
+  ): Promise<string> {
+    const inThread = await this.discordApiClient.isThreadChannel(
+      message.channel_id,
+    );
+    if (inThread) return message.channel_id;
+
+    const threadId = await this.discordApiClient.createThreadFromMessage(
+      message.channel_id,
+      message.id,
+      threadName,
+    );
+    return threadId ?? message.channel_id;
+  }
+
+  private async sendResult(
+    result:
+      | { ok: true; value: string }
+      | { ok: false; error: { message: string } },
+    targetChannelId: string,
+    originalChannelId: string,
+  ): Promise<void> {
+    const log = getLogger();
 
     if (!result.ok) {
       log.error(
-        { error: result.error.message, channelId: message.channel_id },
-        "AI service error in mention handler",
+        { error: result.error.message, channelId: originalChannelId },
+        "AI service error",
+      );
+      await this.discordApiClient.sendMessage(
+        targetChannelId,
+        // biome-ignore lint/security/noSecrets: static Japanese error message, not a secret
+        "エラーが発生しました。しばらくしてからお試しください。",
       );
       return;
     }
 
+    log.info(
+      {
+        channelId: targetChannelId,
+        responseLength: result.value.length,
+        responsePreview: result.value.slice(0, 100),
+      },
+      "Sending AI response",
+    );
+
     const sent = await this.discordApiClient.sendMessage(
-      message.channel_id,
+      targetChannelId,
       result.value,
     );
     if (!sent) {
-      log.error(
-        { channelId: message.channel_id },
-        "Failed to send AI response to Discord",
-      );
+      log.error({ channelId: targetChannelId }, "Failed to send AI response");
     }
   }
 }

--- a/src/infrastructure/discord/discord-api.client.test.ts
+++ b/src/infrastructure/discord/discord-api.client.test.ts
@@ -90,3 +90,295 @@ describe("DiscordApiClient sendMessage error", () => {
     );
   });
 });
+
+describe("DiscordApiClient editInteractionResponse success", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns message ID on success", async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ id: "msg-789" }),
+    });
+    const client = new DiscordApiClient("test-token");
+
+    const result = await client.editInteractionResponse(
+      "app-123",
+      "token-abc",
+      "response content",
+    );
+
+    expect(result).toBe("msg-789");
+  });
+
+  it("returns null when response has no id", async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({}),
+    });
+    const client = new DiscordApiClient("test-token");
+
+    const result = await client.editInteractionResponse(
+      "app-123",
+      "token-abc",
+      "content",
+    );
+
+    expect(result).toBeNull();
+  });
+});
+
+describe("DiscordApiClient editInteractionResponse error", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns null on API error", async () => {
+    mockFetch.mockResolvedValue({
+      ok: false,
+      status: 404,
+      text: () => Promise.resolve("Not found"),
+    });
+    const client = new DiscordApiClient("test-token");
+
+    const result = await client.editInteractionResponse(
+      "app-123",
+      "token-abc",
+      "content",
+    );
+
+    expect(result).toBeNull();
+    expect(mockLogError).toHaveBeenCalledWith(
+      { status: 404, body: "Not found" },
+      "Failed to edit interaction response",
+    );
+  });
+
+  it("returns null on network error", async () => {
+    mockFetch.mockRejectedValue(new Error("ECONNREFUSED"));
+    const client = new DiscordApiClient("test-token");
+
+    const result = await client.editInteractionResponse(
+      "app-123",
+      "token-abc",
+      "content",
+    );
+
+    expect(result).toBeNull();
+    expect(mockLogError).toHaveBeenCalledWith(
+      { err: "ECONNREFUSED" },
+      "Interaction followup request failed",
+    );
+  });
+});
+
+describe("DiscordApiClient createThreadFromMessage success", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns thread channel ID on success", async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ id: "thread-999" }),
+    });
+    const client = new DiscordApiClient("test-token");
+
+    const result = await client.createThreadFromMessage(
+      "ch-123",
+      "msg-456",
+      "AI Chat",
+    );
+
+    expect(result).toBe("thread-999");
+    expect(mockFetch).toHaveBeenCalledWith(
+      "https://discord.com/api/v10/channels/ch-123/messages/msg-456/threads",
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: "Bot test-token",
+        },
+        body: JSON.stringify({
+          name: "AI Chat",
+          auto_archive_duration: 60,
+        }),
+      },
+    );
+  });
+
+  it("returns null when response has no id", async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({}),
+    });
+    const client = new DiscordApiClient("test-token");
+
+    const result = await client.createThreadFromMessage(
+      "ch-123",
+      "msg-456",
+      "AI Chat",
+    );
+
+    expect(result).toBeNull();
+  });
+});
+
+describe("DiscordApiClient createThreadFromMessage error", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns null on API error", async () => {
+    mockFetch.mockResolvedValue({
+      ok: false,
+      status: 403,
+      text: () => Promise.resolve("Forbidden"),
+    });
+    const client = new DiscordApiClient("test-token");
+
+    const result = await client.createThreadFromMessage(
+      "ch-123",
+      "msg-456",
+      "AI Chat",
+    );
+
+    expect(result).toBeNull();
+    expect(mockLogError).toHaveBeenCalledWith(
+      {
+        status: 403,
+        body: "Forbidden",
+        channelId: "ch-123",
+        messageId: "msg-456",
+      },
+      "Failed to create thread",
+    );
+  });
+
+  it("returns null on network error", async () => {
+    mockFetch.mockRejectedValue(new Error("ECONNREFUSED"));
+    const client = new DiscordApiClient("test-token");
+
+    const result = await client.createThreadFromMessage(
+      "ch-123",
+      "msg-456",
+      "AI Chat",
+    );
+
+    expect(result).toBeNull();
+    expect(mockLogError).toHaveBeenCalledWith(
+      { err: "ECONNREFUSED", channelId: "ch-123", messageId: "msg-456" },
+      "Thread creation request failed",
+    );
+  });
+});
+
+const testCommands = [
+  {
+    name: "ping",
+    definition: { description: "Ping-Pong" },
+    execute: vi.fn(),
+  },
+  {
+    name: "chat",
+    definition: {
+      description: "Chat",
+      options: [{ name: "msg", description: "msg", type: 3 }],
+    },
+    execute: vi.fn(),
+  },
+];
+
+describe("DiscordApiClient registerGuildCommands success", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("registers commands via PUT request", async () => {
+    mockFetch.mockResolvedValue({ ok: true });
+    const client = new DiscordApiClient("test-token");
+
+    await client.registerGuildCommands("app-123", "guild-456", testCommands);
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      "https://discord.com/api/v10/applications/app-123/guilds/guild-456/commands",
+      {
+        method: "PUT",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: "Bot test-token",
+        },
+        body: JSON.stringify([
+          { name: "ping", description: "Ping-Pong" },
+          {
+            name: "chat",
+            description: "Chat",
+            options: [{ name: "msg", description: "msg", type: 3 }],
+          },
+        ]),
+      },
+    );
+  });
+
+  it("filters out commands without definition", async () => {
+    mockFetch.mockResolvedValue({ ok: true });
+    const client = new DiscordApiClient("test-token");
+    const commandsWithUndefined = [
+      ...testCommands,
+      { name: "no-def", execute: vi.fn() },
+    ];
+
+    await client.registerGuildCommands(
+      "app-123",
+      "guild-456",
+      commandsWithUndefined as typeof testCommands,
+    );
+
+    const callArgs = mockFetch.mock.calls[0][1];
+    const body = JSON.parse(callArgs.body);
+    expect(body).toHaveLength(2);
+  });
+
+  it("logs info on success", async () => {
+    mockFetch.mockResolvedValue({ ok: true });
+    const client = new DiscordApiClient("test-token");
+
+    await client.registerGuildCommands("app-123", "guild-456", testCommands);
+
+    expect(mockLogInfo).toHaveBeenCalledWith(
+      { guildId: "guild-456", count: 2 },
+      "Guild commands registered",
+    );
+  });
+});
+
+describe("DiscordApiClient registerGuildCommands error", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("logs error on API failure", async () => {
+    mockFetch.mockResolvedValue({ ok: false, status: 401 });
+    const client = new DiscordApiClient("test-token");
+
+    await client.registerGuildCommands("app-123", "guild-456", testCommands);
+
+    expect(mockLogError).toHaveBeenCalledWith(
+      { status: 401, guildId: "guild-456" },
+      "Failed to register guild commands",
+    );
+  });
+
+  it("logs error on network failure", async () => {
+    mockFetch.mockRejectedValue(new Error("ECONNREFUSED"));
+    const client = new DiscordApiClient("test-token");
+
+    await client.registerGuildCommands("app-123", "guild-456", testCommands);
+
+    expect(mockLogError).toHaveBeenCalledWith(
+      { err: "ECONNREFUSED", guildId: "guild-456" },
+      "Guild command registration request failed",
+    );
+  });
+});

--- a/src/infrastructure/discord/discord-api.client.ts
+++ b/src/infrastructure/discord/discord-api.client.ts
@@ -1,9 +1,51 @@
+import type { Command } from "@/bot/commands/command.interface";
 import { getLogger } from "@/shared/utils/logger";
 
 export class DiscordApiClient {
   private readonly baseUrl = "https://discord.com/api/v10";
 
   constructor(private botToken: string) {}
+
+  async registerGuildCommands(
+    applicationId: string,
+    guildId: string,
+    commands: Command[],
+  ): Promise<void> {
+    const log = getLogger();
+    const url = `${this.baseUrl}/applications/${applicationId}/guilds/${guildId}/commands`;
+    const body = commands
+      .filter((c) => c.definition)
+      .map((c) => ({ name: c.name, ...c.definition }));
+
+    try {
+      const response = await fetch(url, {
+        method: "PUT",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bot ${this.botToken}`,
+        },
+        body: JSON.stringify(body),
+      });
+
+      if (!response.ok) {
+        log.error(
+          { status: response.status, guildId },
+          "Failed to register guild commands",
+        );
+        return;
+      }
+
+      log.info({ guildId, count: body.length }, "Guild commands registered");
+    } catch (e) {
+      log.error(
+        {
+          err: e instanceof Error ? e.message : String(e),
+          guildId,
+        },
+        "Guild command registration request failed",
+      );
+    }
+  }
 
   async sendMessage(channelId: string, content: string): Promise<boolean> {
     const log = getLogger();
@@ -32,6 +74,112 @@ export class DiscordApiClient {
       log.error(
         { err: e instanceof Error ? e.message : String(e), channelId },
         "Discord API request failed",
+      );
+      return false;
+    }
+  }
+
+  async editInteractionResponse(
+    applicationId: string,
+    interactionToken: string,
+    content: string,
+  ): Promise<string | null> {
+    const log = getLogger();
+    const url = `${this.baseUrl}/webhooks/${applicationId}/${interactionToken}/messages/@original`;
+
+    try {
+      const response = await fetch(url, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ content }),
+      });
+
+      if (!response.ok) {
+        const body = await response.text();
+        log.error(
+          { status: response.status, body },
+          "Failed to edit interaction response",
+        );
+        return null;
+      }
+
+      const data = (await response.json()) as { id?: string };
+      return data.id ?? null;
+    } catch (e) {
+      log.error(
+        { err: e instanceof Error ? e.message : String(e) },
+        "Interaction followup request failed",
+      );
+      return null;
+    }
+  }
+
+  async createThreadFromMessage(
+    channelId: string,
+    messageId: string,
+    name: string,
+  ): Promise<string | null> {
+    const log = getLogger();
+    const url = `${this.baseUrl}/channels/${channelId}/messages/${messageId}/threads`;
+
+    try {
+      const response = await fetch(url, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bot ${this.botToken}`,
+        },
+        body: JSON.stringify({ name, auto_archive_duration: 60 }),
+      });
+
+      if (!response.ok) {
+        const body = await response.text();
+        log.error(
+          { status: response.status, body, channelId, messageId },
+          "Failed to create thread",
+        );
+        return null;
+      }
+
+      const data = (await response.json()) as { id?: string };
+      return data.id ?? null;
+    } catch (e) {
+      log.error(
+        {
+          err: e instanceof Error ? e.message : String(e),
+          channelId,
+          messageId,
+        },
+        "Thread creation request failed",
+      );
+      return null;
+    }
+  }
+
+  async isThreadChannel(channelId: string): Promise<boolean> {
+    const log = getLogger();
+    const url = `${this.baseUrl}/channels/${channelId}`;
+
+    try {
+      const response = await fetch(url, {
+        headers: { Authorization: `Bot ${this.botToken}` },
+      });
+
+      if (!response.ok) {
+        log.error(
+          { status: response.status, channelId },
+          "Failed to fetch channel info",
+        );
+        return false;
+      }
+
+      const data = (await response.json()) as { type?: number };
+      // 11=public thread, 12=private thread, 13=announcement thread
+      return data.type !== undefined && data.type >= 11 && data.type <= 13;
+    } catch (e) {
+      log.error(
+        { err: e instanceof Error ? e.message : String(e), channelId },
+        "Channel fetch request failed",
       );
       return false;
     }

--- a/src/server/gateway/discord.gateway.test.ts
+++ b/src/server/gateway/discord.gateway.test.ts
@@ -23,6 +23,7 @@ vi.mock("@/app/config/env", () => ({
 
 const mockStartGatewayListener = vi.fn().mockResolvedValue(new Response());
 const mockCreateDiscordAdapter = vi.fn().mockReturnValue({
+  initialize: vi.fn().mockResolvedValue(undefined),
   startGatewayListener: mockStartGatewayListener,
 });
 
@@ -110,16 +111,18 @@ describe("DiscordGateway - start success", () => {
     const gw = new DiscordGateway();
     await gw.start("http://localhost:3000/api/webhooks/discord");
 
-    expect(mockCreateDiscordAdapter).toHaveBeenCalledWith({
-      botToken: "test-token",
-      publicKey: "test-key",
-      applicationId: "test-app-id",
-    });
+    expect(mockCreateDiscordAdapter).toHaveBeenCalledWith(
+      expect.objectContaining({
+        botToken: "test-token",
+        publicKey: "test-key",
+        applicationId: "test-app-id",
+      }),
+    );
 
     const [options, durationMs, signal, url] =
       mockStartGatewayListener.mock.calls[0];
     expect(typeof options.waitUntil).toBe("function");
-    expect(durationMs).toBeUndefined();
+    expect(durationMs).toBe(86_400_000);
     expect(signal).toBeInstanceOf(AbortSignal);
     expect(url).toBe("http://localhost:3000/api/webhooks/discord");
   });

--- a/src/server/gateway/discord.gateway.ts
+++ b/src/server/gateway/discord.gateway.ts
@@ -2,6 +2,29 @@ import { createDiscordAdapter } from "@chat-adapter/discord";
 import { env } from "@/app/config/env";
 import { getLogger } from "@/shared/utils/logger";
 
+const GATEWAY_DURATION_MS = 86_400_000; // 24 hours
+
+function createPinoLoggerAdapter() {
+  const log = getLogger();
+  const wrap =
+    (fn: (msg: string) => void) =>
+    (msg: string, data?: Record<string, unknown>) => {
+      if (data && typeof data === "object" && Object.keys(data).length > 0) {
+        log.info(data, `[gateway] ${msg}`);
+      } else {
+        fn(`[gateway] ${msg}`);
+      }
+    };
+  const logger = {
+    info: wrap((m) => log.info(m)),
+    error: wrap((m) => log.error(m)),
+    warn: wrap((m) => log.warn(m)),
+    debug: wrap((m) => log.debug(m)),
+    child: () => logger,
+  };
+  return logger;
+}
+
 export class DiscordGateway {
   private abortController: AbortController | null = null;
 
@@ -20,12 +43,20 @@ export class DiscordGateway {
       botToken: DISCORD_BOT_TOKEN,
       publicKey: DISCORD_PUBLIC_KEY,
       applicationId: DISCORD_APPLICATION_ID,
+      logger: createPinoLoggerAdapter(),
     });
+    // Adapter requires chat instance for startGatewayListener to proceed
+    await (
+      adapter as { initialize: (chat: unknown) => Promise<void> }
+    ).initialize({});
 
     this.abortController = new AbortController();
 
     log.info(
-      { webhookUrl: webhookUrl ?? "not configured" },
+      {
+        webhookUrl: webhookUrl ?? "not configured",
+        durationHours: GATEWAY_DURATION_MS / 3_600_000,
+      },
       "Starting Gateway listener",
     );
 
@@ -37,10 +68,12 @@ export class DiscordGateway {
           });
         },
       },
-      undefined,
+      GATEWAY_DURATION_MS,
       this.abortController.signal,
       webhookUrl,
     );
+
+    log.info("Gateway listener startGatewayListener returned");
   }
 
   stop(): void {

--- a/src/server/hono.test.ts
+++ b/src/server/hono.test.ts
@@ -4,6 +4,10 @@ vi.mock("@/shared/utils/logger", () => ({
   getLogger: vi.fn().mockReturnValue({ info: vi.fn(), warn: vi.fn() }),
 }));
 
+vi.mock("@/app/config/env", () => ({
+  env: { NODE_ENV: "test" },
+}));
+
 describe("createApp without deps", () => {
   beforeEach(() => {
     vi.resetModules();

--- a/src/server/routes/discord.route.ts
+++ b/src/server/routes/discord.route.ts
@@ -30,6 +30,10 @@ export function createDiscordRoute(deps: {
       }
 
       const raw = await c.req.json();
+      log.debug(
+        { eventType: (raw as Record<string, unknown>)?.type },
+        "Gateway event received",
+      );
       const eventResult = parseGatewayEvent(raw);
 
       if (!eventResult.ok) {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -8,6 +8,9 @@ export default defineConfig({
     },
   },
   test: {
+    env: {
+      NODE_ENV: "test",
+    },
     coverage: {
       provider: "v8",
       reporter: ["text", "lcov", "json-summary"],


### PR DESCRIPTION
# チケット

close #33

# 概要

Botのチャット機能をスレッドベースの対話に対応させ、Guild Commandsの自動登録やCodex SDKの設定カスタマイズなど、本番運用に向けた機能強化を行いました。

### 主な変更点

- **スレッド対応**: ChatCommand・MessageHandlerが自動でスレッドを作成し、AI応答をスレッド内に返信するように変更。既存スレッド内ではそのまま応答。
- **Guild Commands自動登録**: Bootstrap起動時に`DISCORD_GUILD_ID`が設定されていれば、コマンド定義をDiscord APIで自動登録。
- **Deferred Response**: ChatCommandが即座にdeferred response（type 5）を返し、AI処理をバックグラウンドで実行するように変更。
- **CodexClient設定カスタマイズ**: `CODEX_BASE_URL`・`CODEX_API_KEY`・`CODEX_MODEL`環境変数に対応。`CODEX_API_KEY`が未設定時は`OPENAI_API_KEY`にフォールバック。
- **DiscordApiClient拡張**: `registerGuildCommands`・`editInteractionResponse`・`createThreadFromMessage`・`isThreadChannel`の4メソッドを追加。
- **AIService**: `linkThreadChannel`でスレッドチャンネルとオリジナルチャンネル間のthreadId紐付けを追加。
- **DiscordGateway**: Pinoロガーアダプター統合、24時間duration設定、initialize呼び出しを追加。
- **構造化ログ**: InteractionHandler・MessageHandlerにdebug/info/warn/errorログを追加。
- **Docker**: Dockerfileにconfig.yamlコピーと`NODE_ENV=production`を追加。docker-composeにcloudflaredサービスを追加。
- **ビルド**: esbuild設定を`esbuild.config.ts`に抽出し`packages: "external"`を設定。

# その他

resolves #33