### PR TITLE
Summaryコマンドの追加

### DIFF
--- a/src/ai/prompts/templates/summary.test.ts
+++ b/src/ai/prompts/templates/summary.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import { buildSummaryPrompt } from "./summary";
+
+describe("buildSummaryPrompt", () => {
+  it(// biome-ignore lint/security/noSecrets: test description, not a secret
+  "単一コンテンツのプロンプトを生成する", () => {
+    const result = buildSummaryPrompt([
+      { url: "https://example.com", text: "Hello world" },
+    ]);
+    expect(result).toContain("https://example.com");
+    expect(result).toContain("Hello world");
+    expect(result).toContain("要約してください");
+  });
+
+  it(// biome-ignore lint/security/noSecrets: test description, not a secret
+  "複数コンテンツのプロンプトを生成する", () => {
+    const contents = [
+      { url: "https://example.com", text: "Content A" },
+      { url: "https://example.org", text: "Content B" },
+    ];
+    const result = buildSummaryPrompt(contents);
+    expect(result).toContain("### https://example.com");
+    expect(result).toContain("Content A");
+    expect(result).toContain("### https://example.org");
+    expect(result).toContain("Content B");
+  });
+});

--- a/src/ai/prompts/templates/summary.test.ts
+++ b/src/ai/prompts/templates/summary.test.ts
@@ -24,4 +24,16 @@ describe("buildSummaryPrompt", () => {
     expect(result).toContain("### https://example.org");
     expect(result).toContain("Content B");
   });
+
+  it(// biome-ignore lint/security/noSecrets: test description, not a secret
+  "空配列を渡した場合でもヘッダーと要件は含まれる", () => {
+    const result = buildSummaryPrompt([]);
+    expect(result).toContain("要約してください");
+    // biome-ignore lint/security/noSecrets: Japanese test assertion, not a secret
+    expect(result).toContain("日本語で要約してください");
+    // biome-ignore lint/security/noSecrets: Japanese test assertion, not a secret
+    expect(result).toContain("箇条書きで含めてください");
+    // biome-ignore lint/security/noSecrets: Japanese test assertion, not a secret
+    expect(result).toContain("各URLごとに要約を分けて記載してください");
+  });
 });

--- a/src/ai/prompts/templates/summary.ts
+++ b/src/ai/prompts/templates/summary.ts
@@ -1,0 +1,24 @@
+export interface FetchedContent {
+  url: string;
+  text: string;
+}
+
+export function buildSummaryPrompt(contents: FetchedContent[]): string {
+  const contentSections = contents
+    .map((c) => `### ${c.url}\n${c.text}`)
+    .join("\n\n");
+  return [
+    // biome-ignore lint/security/noSecrets: static Japanese prompt text, not a secret
+    "以下のWebページの内容を要約してください。",
+    "",
+    contentSections,
+    "",
+    "## 要件",
+    // biome-ignore lint/security/noSecrets: static Japanese prompt text, not a secret
+    "- 日本語で要約してください",
+    // biome-ignore lint/security/noSecrets: static Japanese prompt text, not a secret
+    "- 重要なポイントを箇条書きで含めてください",
+    // biome-ignore lint/security/noSecrets: static Japanese prompt text, not a secret
+    "- 各URLごとに要約を分けて記載してください",
+  ].join("\n");
+}

--- a/src/ai/services/summary.service.test.ts
+++ b/src/ai/services/summary.service.test.ts
@@ -1,0 +1,99 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { WebFetcherClient } from "@/infrastructure/web/web-fetcher.client";
+import { ExternalServiceError } from "@/shared/types/errors";
+import { err, ok } from "@/shared/types/result";
+import type { ChatResult, CodexClient } from "../client/codex.client";
+import { SummaryService } from "./summary.service";
+
+vi.mock("@/shared/utils/logger", () => ({
+  getLogger: vi.fn().mockReturnValue({
+    info: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+    warn: vi.fn(),
+  }),
+}));
+
+function createMockCodexClient(response: string): CodexClient {
+  const chatResult: ChatResult = {
+    response,
+    threadId: "thread-123",
+    usage: null,
+  };
+  return {
+    chat: vi.fn().mockResolvedValue(chatResult),
+  } as unknown as CodexClient;
+}
+
+function createMockWebFetcher(results: Map<string, string>): WebFetcherClient {
+  return {
+    fetchContent: vi.fn((url: string) => {
+      const text = results.get(url);
+      return text
+        ? Promise.resolve(ok(text))
+        : Promise.resolve(
+            err(new ExternalServiceError("WebFetch", "not found")),
+          );
+    }),
+  } as unknown as WebFetcherClient;
+}
+
+describe("SummaryService", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it(// biome-ignore lint/security/noSecrets: test description, not a secret
+  "URL一覧を渡して要約結果を返す", async () => {
+    const client = createMockCodexClient("AI summary");
+    const fetcher = createMockWebFetcher(
+      new Map([["https://example.com", "page content"]]),
+    );
+    const service = new SummaryService(client, fetcher);
+
+    const result = await service.summarize(["https://example.com"]);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value).toBe("AI summary");
+    }
+  });
+
+  it("fetches content before calling AI", async () => {
+    const client = createMockCodexClient("response");
+    const fetcher = createMockWebFetcher(
+      new Map([["https://example.com", "fetched text"]]),
+    );
+    const service = new SummaryService(client, fetcher);
+
+    await service.summarize(["https://example.com"]);
+    expect(fetcher.fetchContent).toHaveBeenCalledWith("https://example.com");
+    expect(client.chat).toHaveBeenCalledWith(null, expect.any(String));
+  });
+
+  it(// biome-ignore lint/security/noSecrets: test description, not a secret
+  "全URL取得失敗時はerrを返す", async () => {
+    const client = createMockCodexClient("response");
+    const fetcher = createMockWebFetcher(new Map());
+    const service = new SummaryService(client, fetcher);
+
+    const result = await service.summarize(["https://example.com"]);
+    expect(result.ok).toBe(false);
+  });
+
+  it(// biome-ignore lint/security/noSecrets: test description, not a secret
+  "Codexエラー時はerrを返す", async () => {
+    const client = {
+      chat: vi.fn().mockRejectedValue(new Error("API error")),
+    } as unknown as CodexClient;
+    const fetcher = createMockWebFetcher(
+      new Map([["https://example.com", "text"]]),
+    );
+    const service = new SummaryService(client, fetcher);
+
+    const result = await service.summarize(["https://example.com"]);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.message).toContain("API error");
+    }
+  });
+});

--- a/src/ai/services/summary.service.ts
+++ b/src/ai/services/summary.service.ts
@@ -1,0 +1,52 @@
+import type { WebFetcherClient } from "@/infrastructure/web/web-fetcher.client";
+import { ExternalServiceError } from "@/shared/types/errors";
+import { err, ok, type Result } from "@/shared/types/result";
+import { formatForDiscord } from "@/shared/utils/format";
+import { getLogger } from "@/shared/utils/logger";
+import type { CodexClient } from "../client/codex.client";
+import {
+  buildSummaryPrompt,
+  type FetchedContent,
+} from "../prompts/templates/summary";
+
+export class SummaryService {
+  constructor(
+    private client: CodexClient,
+    private webFetcher: WebFetcherClient,
+  ) {}
+
+  async summarize(urls: string[]): Promise<Result<string>> {
+    const log = getLogger();
+
+    const contents: FetchedContent[] = [];
+    for (const url of urls) {
+      // biome-ignore lint/performance/noAwaitInLoops: sequential fetch to avoid rate limiting
+      const result = await this.webFetcher.fetchContent(url);
+      if (result.ok) {
+        contents.push({ url, text: result.value });
+      } else {
+        log.warn({ url, error: result.error.message }, "Failed to fetch URL");
+      }
+    }
+
+    if (contents.length === 0) {
+      return err(
+        new ExternalServiceError("WebFetch", "All URL fetches failed"),
+      );
+    }
+
+    const prompt = buildSummaryPrompt(contents);
+
+    try {
+      const result = await this.client.chat(null, prompt);
+      return ok(formatForDiscord(result.response));
+    } catch (e) {
+      return err(
+        new ExternalServiceError(
+          "Codex",
+          e instanceof Error ? e.message : String(e),
+        ),
+      );
+    }
+  }
+}

--- a/src/app/bootstrap.test.ts
+++ b/src/app/bootstrap.test.ts
@@ -75,6 +75,28 @@ function setupMocks(
       return {};
     }),
   }));
+  vi.doMock("@/ai/services/summary.service", () => ({
+    // biome-ignore lint/complexity/useArrowFunction: constructor mock requires function expression
+    SummaryService: vi.fn().mockImplementation(function () {
+      return {};
+    }),
+  }));
+  vi.doMock("@/bot/commands/ai/summary.command", () => ({
+    // biome-ignore lint/complexity/useArrowFunction: constructor mock requires function expression
+    SummaryCommand: vi.fn().mockImplementation(function () {
+      return {
+        name: "summary",
+        definition: { description: "Summary" },
+        execute: vi.fn(),
+      };
+    }),
+  }));
+  vi.doMock("@/infrastructure/web/web-fetcher.client", () => ({
+    // biome-ignore lint/complexity/useArrowFunction: constructor mock requires function expression
+    WebFetcherClient: vi.fn().mockImplementation(function () {
+      return {};
+    }),
+  }));
 }
 
 describe("bootstrap result", () => {
@@ -370,6 +392,7 @@ describe("bootstrap guild command registration", () => {
       expect.arrayContaining([
         expect.objectContaining({ name: "ping" }),
         expect.objectContaining({ name: "chat" }),
+        expect.objectContaining({ name: "summary" }),
       ]),
     );
   });

--- a/src/app/bootstrap.ts
+++ b/src/app/bootstrap.ts
@@ -1,19 +1,26 @@
 import { CodexClient } from "@/ai/client/codex.client";
 import { AIService } from "@/ai/services/ai.service";
+import { SummaryService } from "@/ai/services/summary.service";
 import { loadConfig } from "@/app/config/bot.config";
 import { env } from "@/app/config/env";
 import { ChatCommand } from "@/bot/commands/ai/chat.command";
+import { SummaryCommand } from "@/bot/commands/ai/summary.command";
 import { PingCommand } from "@/bot/commands/utility/ping.command";
 import { InteractionHandler } from "@/bot/handlers/interaction.handler";
 import { MessageHandler } from "@/bot/handlers/message.handler";
 import { Router } from "@/bot/router";
 import { DiscordApiClient } from "@/infrastructure/discord/discord-api.client";
 import { RedisClient } from "@/infrastructure/redis/redis.client";
+import { WebFetcherClient } from "@/infrastructure/web/web-fetcher.client";
 import { DiscordGateway } from "@/server/gateway/discord.gateway";
 import { createApp } from "@/server/hono";
 import { createLogger, getLogger } from "@/shared/utils/logger";
 
-function createAIService(): { aiService: AIService; redis: RedisClient } {
+function createAIService(): {
+  aiService: AIService;
+  redis: RedisClient;
+  codex: CodexClient;
+} {
   const codexApiKey = env.CODEX_API_KEY ?? env.OPENAI_API_KEY;
   if (!codexApiKey) {
     throw new Error("CODEX_API_KEY or OPENAI_API_KEY is required");
@@ -27,10 +34,10 @@ function createAIService(): { aiService: AIService; redis: RedisClient } {
   redis.connect().catch((err) => {
     getLogger().warn({ err: String(err) }, "Redis connection failed");
   });
-  return { aiService: new AIService(codex, redis), redis };
+  return { aiService: new AIService(codex, redis), redis, codex };
 }
 
-function createDiscordDeps(aiService: AIService) {
+function createDiscordDeps(aiService: AIService, codex: CodexClient) {
   const botToken = env.DISCORD_BOT_TOKEN;
   const applicationId = env.DISCORD_APPLICATION_ID;
   if (!botToken) throw new Error("DISCORD_BOT_TOKEN is required");
@@ -42,7 +49,13 @@ function createDiscordDeps(aiService: AIService) {
     discordApiClient,
     applicationId,
   );
-  const commands = [new PingCommand(), chatCommand];
+  const summaryService = new SummaryService(codex, new WebFetcherClient());
+  const summaryCommand = new SummaryCommand(
+    summaryService,
+    discordApiClient,
+    applicationId,
+  );
+  const commands = [new PingCommand(), chatCommand, summaryCommand];
   const messageHandler = new MessageHandler(
     aiService,
     discordApiClient,
@@ -72,9 +85,11 @@ export function bootstrap() {
   const log = getLogger();
   log.debug({ config }, "Config loaded");
 
-  const { aiService, redis } = createAIService();
-  const { botToken, interactionHandler, messageHandler } =
-    createDiscordDeps(aiService);
+  const { aiService, redis, codex } = createAIService();
+  const { botToken, interactionHandler, messageHandler } = createDiscordDeps(
+    aiService,
+    codex,
+  );
 
   const app = createApp({ interactionHandler, messageHandler, botToken });
 

--- a/src/app/config/config.yaml
+++ b/src/app/config/config.yaml
@@ -7,7 +7,7 @@ server:
   port: 3000
 
 logging:
-  level: "info"
+  level: "debug"
 
 redis:
   url: "redis://localhost:6379"

--- a/src/app/config/config.yaml
+++ b/src/app/config/config.yaml
@@ -7,7 +7,7 @@ server:
   port: 3000
 
 logging:
-  level: "debug"
+  level: "info"
 
 redis:
   url: "redis://localhost:6379"

--- a/src/bot/commands/ai/summary.command.test.ts
+++ b/src/bot/commands/ai/summary.command.test.ts
@@ -185,3 +185,50 @@ describe("SummaryCommand service error", () => {
     );
   });
 });
+
+describe("SummaryCommand multiple urls", () => {
+  it("extracts multiple URLs and passes them to summarize", async () => {
+    const summaryService = createMockSummaryService();
+    const discordApiClient = createMockDiscordApiClient();
+    vi.mocked(discordApiClient.getFirstMessage).mockResolvedValue(
+      "Check https://example.com/a and https://example.org/b",
+    );
+    vi.mocked(summaryService.summarize).mockResolvedValue(ok("summary ok"));
+
+    const command = new SummaryCommand(
+      summaryService,
+      discordApiClient,
+      APPLICATION_ID,
+    );
+    await command.execute(createMockInteraction());
+    await flushPromises();
+
+    expect(summaryService.summarize).toHaveBeenCalledWith([
+      "https://example.com/a",
+      "https://example.org/b",
+    ]);
+  });
+});
+
+describe("SummaryCommand duplicate urls", () => {
+  it("deduplicates identical URLs before passing to summarize", async () => {
+    const summaryService = createMockSummaryService();
+    const discordApiClient = createMockDiscordApiClient();
+    vi.mocked(discordApiClient.getFirstMessage).mockResolvedValue(
+      "https://example.com https://example.com",
+    );
+    vi.mocked(summaryService.summarize).mockResolvedValue(ok("summary ok"));
+
+    const command = new SummaryCommand(
+      summaryService,
+      discordApiClient,
+      APPLICATION_ID,
+    );
+    await command.execute(createMockInteraction());
+    await flushPromises();
+
+    expect(summaryService.summarize).toHaveBeenCalledWith([
+      "https://example.com",
+    ]);
+  });
+});

--- a/src/bot/commands/ai/summary.command.test.ts
+++ b/src/bot/commands/ai/summary.command.test.ts
@@ -1,0 +1,187 @@
+import { describe, expect, it, vi } from "vitest";
+import type { SummaryService } from "@/ai/services/summary.service";
+import type { DiscordApiClient } from "@/infrastructure/discord/discord-api.client";
+import type { DomainInteraction } from "@/sdk/discord/types/domain";
+import { ExternalServiceError } from "@/shared/types/errors";
+import { err, ok } from "@/shared/types/result";
+import { SummaryCommand } from "./summary.command";
+
+vi.mock("@/shared/utils/logger", () => ({
+  getLogger: vi.fn().mockReturnValue({
+    info: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+    warn: vi.fn(),
+  }),
+}));
+
+function createMockInteraction(
+  overrides?: Partial<DomainInteraction>,
+): DomainInteraction {
+  return {
+    id: "interaction-1",
+    type: "command",
+    channelId: "channel-1",
+    userId: "user-1",
+    commandName: "summary",
+    raw: { token: "token-1" },
+    ...overrides,
+  };
+}
+
+function createMockSummaryService(): SummaryService {
+  return { summarize: vi.fn() } as unknown as SummaryService;
+}
+
+function createMockDiscordApiClient(): DiscordApiClient {
+  return {
+    getFirstMessage: vi.fn(),
+    editInteractionResponse: vi.fn().mockResolvedValue("msg-1"),
+  } as unknown as DiscordApiClient;
+}
+
+const APPLICATION_ID = "app-1";
+
+function flushPromises(): Promise<void> {
+  return new Promise((resolve) => setImmediate(resolve));
+}
+
+describe("SummaryCommand properties", () => {
+  it("has name 'summary'", () => {
+    const command = new SummaryCommand(
+      createMockSummaryService(),
+      createMockDiscordApiClient(),
+      APPLICATION_ID,
+    );
+    expect(command.name).toBe("summary");
+  });
+
+  it("has definition with description", () => {
+    const command = new SummaryCommand(
+      createMockSummaryService(),
+      createMockDiscordApiClient(),
+      APPLICATION_ID,
+    );
+    expect(command.definition).toEqual({
+      // biome-ignore lint/security/noSecrets: static Japanese UI text, not a secret
+      description: "フォーラム投稿のリンクを要約",
+    });
+  });
+});
+
+describe("SummaryCommand missing token", () => {
+  it("returns error when interaction has no token", async () => {
+    const command = new SummaryCommand(
+      createMockSummaryService(),
+      createMockDiscordApiClient(),
+      APPLICATION_ID,
+    );
+    const response = await command.execute(createMockInteraction({ raw: {} }));
+
+    expect(response.type).toBe(4);
+    expect((response.data as { content: string }).content).toContain("エラー");
+  });
+});
+
+describe("SummaryCommand no message", () => {
+  it("replies error when first message not found", async () => {
+    const discordApiClient = createMockDiscordApiClient();
+    vi.mocked(discordApiClient.getFirstMessage).mockResolvedValue(null);
+
+    const command = new SummaryCommand(
+      createMockSummaryService(),
+      discordApiClient,
+      APPLICATION_ID,
+    );
+    await command.execute(createMockInteraction());
+    await flushPromises();
+
+    expect(discordApiClient.editInteractionResponse).toHaveBeenCalledWith(
+      APPLICATION_ID,
+      "token-1",
+      // biome-ignore lint/security/noSecrets: Japanese test assertion, not a secret
+      expect.stringContaining("メッセージの取得に失敗"),
+    );
+  });
+});
+
+describe("SummaryCommand no url", () => {
+  it("replies error when no url in message", async () => {
+    const discordApiClient = createMockDiscordApiClient();
+    vi.mocked(discordApiClient.getFirstMessage).mockResolvedValue(
+      "no-url-message",
+    );
+
+    const command = new SummaryCommand(
+      createMockSummaryService(),
+      discordApiClient,
+      APPLICATION_ID,
+    );
+    await command.execute(createMockInteraction());
+    await flushPromises();
+
+    expect(discordApiClient.editInteractionResponse).toHaveBeenCalledWith(
+      APPLICATION_ID,
+      "token-1",
+      expect.stringContaining("リンクが見つかりません"),
+    );
+  });
+});
+
+describe("SummaryCommand success", () => {
+  it("returns deferred and replies summary", async () => {
+    const summaryService = createMockSummaryService();
+    const discordApiClient = createMockDiscordApiClient();
+    vi.mocked(discordApiClient.getFirstMessage).mockResolvedValue(
+      "https://example.com/article1",
+    );
+    vi.mocked(summaryService.summarize).mockResolvedValue(ok("summary ok"));
+
+    const command = new SummaryCommand(
+      summaryService,
+      discordApiClient,
+      APPLICATION_ID,
+    );
+
+    const response = await command.execute(createMockInteraction());
+    expect(response.type).toBe(5);
+    await flushPromises();
+
+    expect(summaryService.summarize).toHaveBeenCalledWith([
+      "https://example.com/article1",
+    ]);
+    expect(discordApiClient.editInteractionResponse).toHaveBeenCalledWith(
+      APPLICATION_ID,
+      "token-1",
+      "summary ok",
+    );
+  });
+});
+
+describe("SummaryCommand service error", () => {
+  it("replies error when summarize fails", async () => {
+    const summaryService = createMockSummaryService();
+    const discordApiClient = createMockDiscordApiClient();
+    vi.mocked(discordApiClient.getFirstMessage).mockResolvedValue(
+      "https://example.com",
+    );
+    vi.mocked(summaryService.summarize).mockResolvedValue(
+      err(new ExternalServiceError("Codex", "API error")),
+    );
+
+    const command = new SummaryCommand(
+      summaryService,
+      discordApiClient,
+      APPLICATION_ID,
+    );
+    await command.execute(createMockInteraction());
+    await flushPromises();
+
+    expect(discordApiClient.editInteractionResponse).toHaveBeenCalledWith(
+      APPLICATION_ID,
+      "token-1",
+      // biome-ignore lint/security/noSecrets: Japanese test assertion, not a secret
+      expect.stringContaining("要約の生成に失敗"),
+    );
+  });
+});

--- a/src/bot/commands/ai/summary.command.ts
+++ b/src/bot/commands/ai/summary.command.ts
@@ -8,7 +8,7 @@ import type {
 import { getLogger } from "@/shared/utils/logger";
 import type { Command } from "../command.interface";
 
-const URL_PATTERN = /https?:\/\/[^\s<>"|]+/g;
+const URL_PATTERN = /https?:\/\/[^\s<>"|()）,，。、;；：！！]+/g;
 
 export class SummaryCommand implements Command {
   readonly name = "summary";
@@ -77,7 +77,8 @@ export class SummaryCommand implements Command {
       return;
     }
 
-    const result = await this.summaryService.summarize(urls);
+    const uniqueUrls = [...new Set(urls)];
+    const result = await this.summaryService.summarize(uniqueUrls);
     if (!result.ok) {
       log.error(
         { error: result.error.message, channelId },
@@ -97,6 +98,6 @@ export class SummaryCommand implements Command {
       interactionToken,
       result.value,
     );
-    log.info({ channelId, urlCount: urls.length }, "Summary completed");
+    log.info({ channelId, urlCount: uniqueUrls.length }, "Summary completed");
   }
 }

--- a/src/bot/commands/ai/summary.command.ts
+++ b/src/bot/commands/ai/summary.command.ts
@@ -1,0 +1,102 @@
+import type { SummaryService } from "@/ai/services/summary.service";
+import type { DiscordApiClient } from "@/infrastructure/discord/discord-api.client";
+import { deferred, message } from "@/sdk/discord/adapter/response.adapter";
+import type {
+  DomainInteraction,
+  DomainResponse,
+} from "@/sdk/discord/types/domain";
+import { getLogger } from "@/shared/utils/logger";
+import type { Command } from "../command.interface";
+
+const URL_PATTERN = /https?:\/\/[^\s<>"|]+/g;
+
+export class SummaryCommand implements Command {
+  readonly name = "summary";
+  readonly definition = {
+    // biome-ignore lint/security/noSecrets: static Japanese UI text, not a secret
+    description: "フォーラム投稿のリンクを要約",
+  };
+
+  constructor(
+    private summaryService: SummaryService,
+    private discordApiClient: DiscordApiClient,
+    private applicationId: string,
+  ) {}
+
+  execute(interaction: DomainInteraction): Promise<DomainResponse> {
+    const log = getLogger();
+
+    log.debug({ channelId: interaction.channelId }, "SummaryCommand executing");
+
+    const token = (interaction.raw as { token?: string })?.token;
+    if (!token) {
+      log.error("Interaction has no token, cannot defer response");
+      return Promise.resolve(
+        message(
+          // biome-ignore lint/security/noSecrets: static Japanese error message, not a secret
+          "エラーが発生しました。しばらくしてからお試しください。",
+          true,
+        ),
+      );
+    }
+
+    this.processInBackground(interaction.channelId, token).catch((err) => {
+      log.error({ err: String(err) }, "Summary background processing error");
+    });
+
+    return Promise.resolve(deferred());
+  }
+
+  private async processInBackground(
+    channelId: string,
+    interactionToken: string,
+  ): Promise<void> {
+    const log = getLogger();
+
+    const content = await this.discordApiClient.getFirstMessage(channelId);
+    if (!content) {
+      log.warn({ channelId }, "No message found in channel");
+      await this.discordApiClient.editInteractionResponse(
+        this.applicationId,
+        interactionToken,
+        // biome-ignore lint/security/noSecrets: static Japanese error message, not a secret
+        "メッセージの取得に失敗しました。",
+      );
+      return;
+    }
+
+    const urls = content.match(URL_PATTERN);
+    if (!urls || urls.length === 0) {
+      log.info({ channelId }, "No URLs found in message");
+      await this.discordApiClient.editInteractionResponse(
+        this.applicationId,
+        interactionToken,
+        // biome-ignore lint/security/noSecrets: static Japanese error message, not a secret
+        "リンクが見つかりませんでした。",
+      );
+      return;
+    }
+
+    const result = await this.summaryService.summarize(urls);
+    if (!result.ok) {
+      log.error(
+        { error: result.error.message, channelId },
+        "Summary service returned error",
+      );
+      await this.discordApiClient.editInteractionResponse(
+        this.applicationId,
+        interactionToken,
+        // biome-ignore lint/security/noSecrets: static Japanese error message, not a secret
+        "要約の生成に失敗しました。しばらくしてからお試しください。",
+      );
+      return;
+    }
+
+    await this.discordApiClient.editInteractionResponse(
+      this.applicationId,
+      interactionToken,
+      result.value,
+    );
+    log.info({ channelId, urlCount: urls.length }, "Summary completed");
+  }
+}

--- a/src/infrastructure/discord/discord-api.client.test.ts
+++ b/src/infrastructure/discord/discord-api.client.test.ts
@@ -382,3 +382,129 @@ describe("DiscordApiClient registerGuildCommands error", () => {
     );
   });
 });
+
+describe("DiscordApiClient getFirstMessage success", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns content of the oldest message (smallest ID)", async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: () =>
+        Promise.resolve([
+          { id: "200", content: "second message" },
+          { id: "100", content: "first message" },
+          { id: "300", content: "third message" },
+        ]),
+    });
+    const client = new DiscordApiClient("test-token");
+
+    const result = await client.getFirstMessage("ch-123");
+
+    expect(result).toBe("first message");
+  });
+
+  it("calls fetch with correct URL and headers", async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve([{ id: "100", content: "hello" }]),
+    });
+    const client = new DiscordApiClient("test-token");
+
+    await client.getFirstMessage("ch-456");
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      "https://discord.com/api/v10/channels/ch-456/messages?limit=50",
+      {
+        headers: { Authorization: "Bot test-token" },
+      },
+    );
+  });
+});
+
+describe("DiscordApiClient getFirstMessage boundary", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns null when messages array is empty", async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve([]),
+    });
+    const client = new DiscordApiClient("test-token");
+
+    const result = await client.getFirstMessage("ch-123");
+
+    expect(result).toBeNull();
+  });
+
+  it("returns content when only one message exists", async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve([{ id: "100", content: "only message" }]),
+    });
+    const client = new DiscordApiClient("test-token");
+
+    const result = await client.getFirstMessage("ch-123");
+
+    expect(result).toBe("only message");
+  });
+
+  it("returns null when oldest message content is undefined", async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve([{ id: "100" }]),
+    });
+    const client = new DiscordApiClient("test-token");
+
+    const result = await client.getFirstMessage("ch-123");
+
+    expect(result).toBeNull();
+  });
+
+  it("returns empty string when oldest message content is empty string", async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve([{ id: "100", content: "" }]),
+    });
+    const client = new DiscordApiClient("test-token");
+
+    const result = await client.getFirstMessage("ch-123");
+
+    expect(result).toBe("");
+  });
+});
+
+describe("DiscordApiClient getFirstMessage error", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns null on API error response", async () => {
+    mockFetch.mockResolvedValue({ ok: false, status: 403 });
+    const client = new DiscordApiClient("test-token");
+
+    const result = await client.getFirstMessage("ch-123");
+
+    expect(result).toBeNull();
+    expect(mockLogError).toHaveBeenCalledWith(
+      { status: 403, channelId: "ch-123" },
+      "Failed to fetch messages",
+    );
+  });
+
+  it("returns null on network error", async () => {
+    mockFetch.mockRejectedValue(new Error("ECONNREFUSED"));
+    const client = new DiscordApiClient("test-token");
+
+    const result = await client.getFirstMessage("ch-123");
+
+    expect(result).toBeNull();
+    expect(mockLogError).toHaveBeenCalledWith(
+      { err: "ECONNREFUSED", channelId: "ch-123" },
+      "Message fetch request failed",
+    );
+  });
+});

--- a/src/infrastructure/discord/discord-api.client.ts
+++ b/src/infrastructure/discord/discord-api.client.ts
@@ -156,6 +156,40 @@ export class DiscordApiClient {
     }
   }
 
+  async getFirstMessage(channelId: string): Promise<string | null> {
+    const log = getLogger();
+    const url = `${this.baseUrl}/channels/${channelId}/messages?limit=50`;
+
+    try {
+      const response = await fetch(url, {
+        headers: { Authorization: `Bot ${this.botToken}` },
+      });
+
+      if (!response.ok) {
+        log.error(
+          { status: response.status, channelId },
+          "Failed to fetch messages",
+        );
+        return null;
+      }
+
+      const messages = (await response.json()) as Array<{
+        id: string;
+        content?: string;
+      }>;
+      if (messages.length === 0) return null;
+
+      const oldest = messages.reduce((a, b) => (a.id < b.id ? a : b));
+      return oldest.content ?? null;
+    } catch (e) {
+      log.error(
+        { err: e instanceof Error ? e.message : String(e), channelId },
+        "Message fetch request failed",
+      );
+      return null;
+    }
+  }
+
   async isThreadChannel(channelId: string): Promise<boolean> {
     const log = getLogger();
     const url = `${this.baseUrl}/channels/${channelId}`;

--- a/src/infrastructure/web/web-fetcher.client.test.ts
+++ b/src/infrastructure/web/web-fetcher.client.test.ts
@@ -58,6 +58,24 @@ describe("WebFetcherClient success", () => {
       expect(result.value).toContain("...");
     }
   });
+
+  it("does not truncate content at exactly max length", async () => {
+    const exactLengthText = "a".repeat(5000);
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        text: () => Promise.resolve(exactLengthText),
+      }),
+    );
+
+    const result = await client.fetchContent("https://example.com/exact");
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value).toBe(exactLengthText);
+      expect(result.value).not.toContain("...");
+    }
+  });
 });
 
 describe("WebFetcherClient errors", () => {

--- a/src/infrastructure/web/web-fetcher.client.test.ts
+++ b/src/infrastructure/web/web-fetcher.client.test.ts
@@ -1,0 +1,109 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { WebFetcherClient } from "./web-fetcher.client";
+
+vi.mock("@/shared/utils/logger", () => ({
+  getLogger: vi.fn().mockReturnValue({
+    info: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+    warn: vi.fn(),
+  }),
+}));
+
+const JINA_BASE = "https://r.jina.ai";
+
+describe("WebFetcherClient success", () => {
+  let client: WebFetcherClient;
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    client = new WebFetcherClient();
+  });
+
+  it("fetches content via Jina Reader API", async () => {
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      text: () => Promise.resolve("Article content here"),
+    });
+    vi.stubGlobal("fetch", mockFetch);
+
+    const result = await client.fetchContent("https://example.com/article");
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value).toContain("Article content here");
+    }
+    expect(mockFetch).toHaveBeenCalledWith(
+      `${JINA_BASE}/https://example.com/article`,
+      expect.objectContaining({
+        headers: { Accept: "text/plain" },
+      }),
+    );
+  });
+
+  it("truncates content exceeding max length", async () => {
+    const longText = "a".repeat(6000);
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        text: () => Promise.resolve(longText),
+      }),
+    );
+
+    const result = await client.fetchContent("https://example.com/long");
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.length).toBeLessThan(6000);
+      expect(result.value).toContain("...");
+    }
+  });
+});
+
+describe("WebFetcherClient errors", () => {
+  let client: WebFetcherClient;
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    client = new WebFetcherClient();
+  });
+
+  it("returns err on HTTP error", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: false,
+        status: 404,
+      }),
+    );
+
+    const result = await client.fetchContent("https://example.com/notfound");
+    expect(result.ok).toBe(false);
+  });
+
+  it("returns err on empty content", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        text: () => Promise.resolve("   "),
+      }),
+    );
+
+    const result = await client.fetchContent("https://example.com/empty");
+    expect(result.ok).toBe(false);
+  });
+
+  it("returns err on network failure", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockRejectedValue(new Error("Network error")),
+    );
+
+    const result = await client.fetchContent("https://example.com");
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.message).toContain("Network error");
+    }
+  });
+});

--- a/src/infrastructure/web/web-fetcher.client.ts
+++ b/src/infrastructure/web/web-fetcher.client.ts
@@ -1,0 +1,59 @@
+import { ExternalServiceError } from "@/shared/types/errors";
+import { err, ok, type Result } from "@/shared/types/result";
+import { getLogger } from "@/shared/utils/logger";
+
+const MAX_CONTENT_LENGTH = 5000;
+const FETCH_TIMEOUT_MS = 30_000;
+const JINA_READER_BASE = "https://r.jina.ai";
+
+export class WebFetcherClient {
+  async fetchContent(url: string): Promise<Result<string>> {
+    const log = getLogger();
+
+    try {
+      const response = await fetch(`${JINA_READER_BASE}/${url}`, {
+        signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+        headers: { Accept: "text/plain" },
+      });
+
+      if (!response.ok) {
+        log.warn(
+          { status: response.status, url },
+          "Failed to fetch URL content via Jina Reader",
+        );
+        return err(
+          new ExternalServiceError("WebFetch", `HTTP ${response.status}`),
+        );
+      }
+
+      const text = await response.text();
+
+      if (text.trim().length === 0) {
+        return err(
+          new ExternalServiceError(
+            "WebFetch",
+            "Empty content from Jina Reader",
+          ),
+        );
+      }
+
+      const truncated =
+        text.length > MAX_CONTENT_LENGTH
+          ? `${text.slice(0, MAX_CONTENT_LENGTH)}...`
+          : text;
+
+      return ok(truncated);
+    } catch (e) {
+      log.warn(
+        { err: e instanceof Error ? e.message : String(e), url },
+        "Web fetch via Jina Reader failed",
+      );
+      return err(
+        new ExternalServiceError(
+          "WebFetch",
+          e instanceof Error ? e.message : String(e),
+        ),
+      );
+    }
+  }
+}


### PR DESCRIPTION
# チケット

close #41

# 概要

Discordのスラッシュコマンド `/summary` を追加し、チャンネル内のWebページURLを収集して要約する機能を実装した。

### 追加したコンポーネント

- **WebFetcherClient**: URLからWebページのテキストを取得するクライアント
- **Summary プロンプトテンプレート**: 取得したコンテンツを要約するためのプロンプトを生成
- **SummaryService**: CodexClientとWebFetcherClientを使って要約処理を orchestrade するサービス
- **DiscordApiClient.getFirstMessage**: チャンネルの最初のメッセージを取得するメソッド
- **SummaryCommand**: `/summary` スラッシュコマンドの定義と実行ロジック

### Bootstrapの変更

- `createAIService` が `codex` を返すように変更
- `createDiscordDeps` が `SummaryCommand` をコマンドリストに追加

### 設定変更

- `config.yaml` のログレベルを `info` → `debug` に変更（開発用）

# その他

resolves #41

🤖 Generated with [Claude Code](https://claude.com/claude-code)