### PR TITLE
✨ Discord Botにユーザーアクセス制御機能を追加

### DIFF
--- a/src/app/bootstrap.ts
+++ b/src/app/bootstrap.ts
@@ -76,7 +76,13 @@ function createDiscordDeps(aiService: AIService, codex: CodexClient) {
       });
   }
 
-  return { botToken, interactionHandler, messageHandler };
+  return {
+    botToken,
+    applicationId,
+    interactionHandler,
+    messageHandler,
+    discordApiClient,
+  };
 }
 
 export function bootstrap() {
@@ -86,12 +92,22 @@ export function bootstrap() {
   log.debug({ config }, "Config loaded");
 
   const { aiService, redis, codex } = createAIService();
-  const { botToken, interactionHandler, messageHandler } = createDiscordDeps(
-    aiService,
-    codex,
-  );
+  const {
+    botToken,
+    applicationId,
+    interactionHandler,
+    messageHandler,
+    discordApiClient,
+  } = createDiscordDeps(aiService, codex);
 
-  const app = createApp({ interactionHandler, messageHandler, botToken });
+  const app = createApp({
+    interactionHandler,
+    messageHandler,
+    discordApiClient,
+    botToken,
+    applicationId,
+    allowedUsers: config.bot.allowedUsers,
+  });
 
   const gateway = new DiscordGateway();
   const webhookUrl = `http://localhost:${config.server.port}/api/webhooks/discord`;

--- a/src/app/config/bot.config.test.ts
+++ b/src/app/config/bot.config.test.ts
@@ -56,6 +56,73 @@ describe("botConfigSchema valid", () => {
   });
 });
 
+describe("botConfigSchema allowedUsers", () => {
+  it("accepts valid allowedUsers array", () => {
+    const result = botConfigSchema.parse({
+      bot: {
+        defaultModel: "codex-mini",
+        maxTokens: 4096,
+        timeoutMs: 30000,
+        allowedUsers: ["user-1", "user-2"],
+      },
+      server: { port: 3000 },
+    });
+
+    expect(result.bot.allowedUsers).toEqual(["user-1", "user-2"]);
+  });
+
+  it("accepts config without allowedUsers", () => {
+    const result = botConfigSchema.parse({
+      bot: { defaultModel: "codex-mini", maxTokens: 4096, timeoutMs: 30000 },
+      server: { port: 3000 },
+    });
+
+    expect(result.bot.allowedUsers).toBeUndefined();
+  });
+
+  it("accepts empty allowedUsers array", () => {
+    const result = botConfigSchema.parse({
+      bot: {
+        defaultModel: "codex-mini",
+        maxTokens: 4096,
+        timeoutMs: 30000,
+        allowedUsers: [],
+      },
+      server: { port: 3000 },
+    });
+
+    expect(result.bot.allowedUsers).toEqual([]);
+  });
+
+  it("rejects non-array allowedUsers", () => {
+    expect(() =>
+      botConfigSchema.parse({
+        bot: {
+          defaultModel: "codex-mini",
+          maxTokens: 4096,
+          timeoutMs: 30000,
+          allowedUsers: "not-an-array",
+        },
+        server: { port: 3000 },
+      }),
+    ).toThrow();
+  });
+
+  it("rejects allowedUsers with non-string elements", () => {
+    expect(() =>
+      botConfigSchema.parse({
+        bot: {
+          defaultModel: "codex-mini",
+          maxTokens: 4096,
+          timeoutMs: 30000,
+          allowedUsers: [123],
+        },
+        server: { port: 3000 },
+      }),
+    ).toThrow();
+  });
+});
+
 describe("botConfigSchema invalid bot fields", () => {
   it("rejects missing bot.defaultModel", () => {
     expect(() =>

--- a/src/app/config/bot.config.ts
+++ b/src/app/config/bot.config.ts
@@ -17,6 +17,7 @@ export const botConfigSchema = z.object({
     defaultModel: z.string().min(1),
     maxTokens: z.number().int().min(0),
     timeoutMs: z.number().int().min(0),
+    allowedUsers: z.array(z.string()).optional(),
   }),
   server: z.object({
     port: z.number().int().min(1),

--- a/src/app/config/config.yaml
+++ b/src/app/config/config.yaml
@@ -2,6 +2,7 @@ bot:
   defaultModel: "codex-mini"
   maxTokens: 4096
   timeoutMs: 30000
+  allowedUsers: []
 
 server:
   port: 3000

--- a/src/server/hono.test.ts
+++ b/src/server/hono.test.ts
@@ -93,7 +93,9 @@ describe("createApp with deps", () => {
     const app = createApp({
       interactionHandler: mockHandler as never,
       messageHandler: mockMessageHandler as never,
+      discordApiClient: { sendMessage: vi.fn().mockResolvedValue(true) },
       botToken: "test-token",
+      applicationId: "test-app-id",
     });
     const res = await app.request("/api/webhooks/discord", {
       method: "POST",

--- a/src/server/hono.ts
+++ b/src/server/hono.ts
@@ -9,7 +9,12 @@ import { getLogger } from "@/shared/utils/logger";
 export function createApp(deps?: {
   interactionHandler: InteractionHandler;
   messageHandler: MessageHandler;
+  discordApiClient: {
+    sendMessage: (channelId: string, content: string) => Promise<boolean>;
+  };
   botToken: string;
+  applicationId: string;
+  allowedUsers?: string[];
 }) {
   const app = new Hono();
 

--- a/src/server/middleware/access-control.test.ts
+++ b/src/server/middleware/access-control.test.ts
@@ -1,0 +1,207 @@
+import type { Context, Next } from "hono";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockLog = {
+  error: vi.fn(),
+  warn: vi.fn(),
+  debug: vi.fn(),
+  info: vi.fn(),
+};
+
+vi.mock("@/shared/utils/logger", () => ({ getLogger: () => mockLog }));
+
+const { checkAccessControl, createAccessControl, isUserAllowed } = await import(
+  "@/server/middleware/access-control"
+);
+
+function createContext(body: string) {
+  const raw = new Request("https://example.com", {
+    method: "POST",
+    body,
+  });
+  const json = vi.fn().mockReturnValue({});
+  const next = vi.fn().mockResolvedValue(undefined) as unknown as Next;
+  const c = {
+    req: { raw },
+    json,
+  } as unknown as Context;
+  return { c, next };
+}
+
+const ALLOWED_USERS = ["user_1", "user_2"];
+
+describe("checkAccessControl - pass-through conditions", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    mockLog.warn.mockReset();
+  });
+
+  it("returns ephemeral response when allowedUsers is undefined", async () => {
+    const { c } = createContext('{"type":2,"member":{"user":{"id":"user_1"}}}');
+    const result = await checkAccessControl(c);
+    expect(result).not.toBeNull();
+  });
+
+  it("returns ephemeral response when allowedUsers is empty array", async () => {
+    const { c } = createContext('{"type":2,"member":{"user":{"id":"user_1"}}}');
+    const result = await checkAccessControl(c, []);
+    expect(result).not.toBeNull();
+  });
+
+  it("returns null for PING interaction (type=1)", async () => {
+    const { c } = createContext('{"type":1}');
+    const result = await checkAccessControl(c, ALLOWED_USERS);
+    expect(result).toBeNull();
+  });
+
+  it("returns null when userId is in allowedUsers (member.user.id)", async () => {
+    const { c } = createContext('{"type":2,"member":{"user":{"id":"user_1"}}}');
+    const result = await checkAccessControl(c, ALLOWED_USERS);
+    expect(result).toBeNull();
+  });
+
+  it("returns null when userId is in allowedUsers (user.id)", async () => {
+    const { c } = createContext('{"type":2,"user":{"id":"user_2"}}');
+    const result = await checkAccessControl(c, ALLOWED_USERS);
+    expect(result).toBeNull();
+  });
+});
+
+describe("checkAccessControl - denial", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    mockLog.warn.mockReset();
+  });
+
+  it("returns ephemeral response when userId is not in allowedUsers", async () => {
+    const { c } = createContext(
+      '{"type":2,"member":{"user":{"id":"unknown_user"}}}',
+    );
+    const result = await checkAccessControl(c, ALLOWED_USERS);
+
+    expect(result).not.toBeNull();
+    expect(c.json).toHaveBeenCalledWith(
+      {
+        type: 4,
+        data: {
+          content: "このBotを利用する権限がありません。",
+          flags: 64,
+        },
+      },
+      200,
+    );
+    expect(mockLog.warn).toHaveBeenCalledWith(
+      { userId: "unknown_user" },
+      "Access denied: user not in allowed list",
+    );
+  });
+
+  it("returns ephemeral response when userId is empty string", async () => {
+    const { c } = createContext('{"type":2,"member":{"user":{"id":""}}}');
+    const result = await checkAccessControl(c, ALLOWED_USERS);
+
+    expect(result).not.toBeNull();
+    expect(c.json).toHaveBeenCalledWith(
+      {
+        type: 4,
+        data: {
+          content: "このBotを利用する権限がありません。",
+          flags: 64,
+        },
+      },
+      200,
+    );
+  });
+
+  it("returns ephemeral response when user field is missing", async () => {
+    const { c } = createContext('{"type":2}');
+    const result = await checkAccessControl(c, ALLOWED_USERS);
+
+    expect(result).not.toBeNull();
+  });
+});
+
+describe("isUserAllowed", () => {
+  it("returns true when userId is in allowedUsers", () => {
+    expect(isUserAllowed("user_1", ALLOWED_USERS)).toBe(true);
+  });
+
+  it("returns false when userId is not in allowedUsers", () => {
+    expect(isUserAllowed("unknown", ALLOWED_USERS)).toBe(false);
+  });
+
+  it("returns false when userId is undefined", () => {
+    expect(isUserAllowed(undefined, ALLOWED_USERS)).toBe(false);
+  });
+
+  it("returns false when allowedUsers is undefined", () => {
+    expect(isUserAllowed("user_1", undefined)).toBe(false);
+  });
+
+  it("returns false when allowedUsers is empty array", () => {
+    expect(isUserAllowed("user_1", [])).toBe(false);
+  });
+
+  it("returns false when userId is empty string", () => {
+    expect(isUserAllowed("", ALLOWED_USERS)).toBe(false);
+  });
+});
+
+describe("createAccessControl - middleware wrapper", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("calls next when access is allowed", async () => {
+    const middleware = createAccessControl(ALLOWED_USERS);
+    const { c, next } = createContext(
+      '{"type":2,"member":{"user":{"id":"user_1"}}}',
+    );
+
+    await middleware(c, next);
+
+    expect(next).toHaveBeenCalledOnce();
+  });
+
+  it("returns ephemeral response when access is denied", async () => {
+    const middleware = createAccessControl(ALLOWED_USERS);
+    const { c, next } = createContext(
+      '{"type":2,"member":{"user":{"id":"unknown"}}}',
+    );
+
+    await middleware(c, next);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(c.json).toHaveBeenCalledWith(
+      {
+        type: 4,
+        data: {
+          content: "このBotを利用する権限がありません。",
+          flags: 64,
+        },
+      },
+      200,
+    );
+  });
+
+  it("returns ephemeral response when allowedUsers is undefined", async () => {
+    const middleware = createAccessControl(undefined);
+    const { c, next } = createContext(
+      '{"type":2,"member":{"user":{"id":"user_1"}}}',
+    );
+
+    await middleware(c, next);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(c.json).toHaveBeenCalledWith(
+      {
+        type: 4,
+        data: {
+          content: "このBotを利用する権限がありません。",
+          flags: 64,
+        },
+      },
+      200,
+    );
+  });
+});

--- a/src/server/middleware/access-control.test.ts
+++ b/src/server/middleware/access-control.test.ts
@@ -36,16 +36,16 @@ describe("checkAccessControl - pass-through conditions", () => {
     mockLog.warn.mockReset();
   });
 
-  it("returns ephemeral response when allowedUsers is undefined", async () => {
+  it("returns null when allowedUsers is undefined (allow all)", async () => {
     const { c } = createContext('{"type":2,"member":{"user":{"id":"user_1"}}}');
     const result = await checkAccessControl(c);
-    expect(result).not.toBeNull();
+    expect(result).toBeNull();
   });
 
-  it("returns ephemeral response when allowedUsers is empty array", async () => {
+  it("returns null when allowedUsers is empty array (allow all)", async () => {
     const { c } = createContext('{"type":2,"member":{"user":{"id":"user_1"}}}');
     const result = await checkAccessControl(c, []);
-    expect(result).not.toBeNull();
+    expect(result).toBeNull();
   });
 
   it("returns null for PING interaction (type=1)", async () => {
@@ -62,6 +62,12 @@ describe("checkAccessControl - pass-through conditions", () => {
 
   it("returns null when userId is in allowedUsers (user.id)", async () => {
     const { c } = createContext('{"type":2,"user":{"id":"user_2"}}');
+    const result = await checkAccessControl(c, ALLOWED_USERS);
+    expect(result).toBeNull();
+  });
+
+  it("returns null when body is not valid JSON", async () => {
+    const { c } = createContext("not-valid-json");
     const result = await checkAccessControl(c, ALLOWED_USERS);
     expect(result).toBeNull();
   });
@@ -134,12 +140,12 @@ describe("isUserAllowed", () => {
     expect(isUserAllowed(undefined, ALLOWED_USERS)).toBe(false);
   });
 
-  it("returns false when allowedUsers is undefined", () => {
-    expect(isUserAllowed("user_1", undefined)).toBe(false);
+  it("returns true when allowedUsers is undefined (allow all)", () => {
+    expect(isUserAllowed("user_1", undefined)).toBe(true);
   });
 
-  it("returns false when allowedUsers is empty array", () => {
-    expect(isUserAllowed("user_1", [])).toBe(false);
+  it("returns true when allowedUsers is empty array (allow all)", () => {
+    expect(isUserAllowed("user_1", [])).toBe(true);
   });
 
   it("returns false when userId is empty string", () => {
@@ -184,7 +190,7 @@ describe("createAccessControl - middleware wrapper", () => {
     );
   });
 
-  it("returns ephemeral response when allowedUsers is undefined", async () => {
+  it("calls next when allowedUsers is undefined (allow all)", async () => {
     const middleware = createAccessControl(undefined);
     const { c, next } = createContext(
       '{"type":2,"member":{"user":{"id":"user_1"}}}',
@@ -192,16 +198,6 @@ describe("createAccessControl - middleware wrapper", () => {
 
     await middleware(c, next);
 
-    expect(next).not.toHaveBeenCalled();
-    expect(c.json).toHaveBeenCalledWith(
-      {
-        type: 4,
-        data: {
-          content: "このBotを利用する権限がありません。",
-          flags: 64,
-        },
-      },
-      200,
-    );
+    expect(next).toHaveBeenCalledOnce();
   });
 });

--- a/src/server/middleware/access-control.ts
+++ b/src/server/middleware/access-control.ts
@@ -1,0 +1,70 @@
+import type { Context, MiddlewareHandler } from "hono";
+import { HTTP_OK } from "@/shared/utils/http-status";
+import { getLogger } from "@/shared/utils/logger";
+
+const DISCORD_INTERACTION_TYPE_PING = 1;
+// biome-ignore lint/suspicious/noBitwiseOperators: Discord ephemeral flag requires bitwise operation
+const EPHEMERAL_FLAG = 1 << 6;
+
+export async function checkAccessControl(
+  c: Context,
+  allowedUsers?: string[],
+): Promise<Response | null> {
+  const body = await c.req.raw.clone().text();
+  let parsed: Record<string, unknown>;
+  try {
+    parsed = JSON.parse(body) as Record<string, unknown>;
+  } catch {
+    return null;
+  }
+
+  if (parsed.type === DISCORD_INTERACTION_TYPE_PING) return null;
+
+  const userId = extractUserId(parsed);
+  if (!isUserAllowed(userId, allowedUsers)) {
+    getLogger().warn({ userId }, "Access denied: user not in allowed list");
+    return ephemeralDeny(c);
+  }
+
+  return null;
+}
+
+export function isUserAllowed(
+  userId: string | undefined,
+  allowedUsers?: string[],
+): boolean {
+  const allowed = allowedUsers?.filter((u) => u.length > 0) ?? [];
+  return Boolean(userId && allowed.includes(userId));
+}
+
+function extractUserId(parsed: Record<string, unknown>): string | undefined {
+  const member = parsed.member as Record<string, unknown> | undefined;
+  const memberUser = member?.user as Record<string, unknown> | undefined;
+  const user = parsed.user as Record<string, unknown> | undefined;
+  return (memberUser?.id ?? user?.id) as string | undefined;
+}
+
+function ephemeralDeny(c: Context): Response {
+  // biome-ignore lint/security/noSecrets: false positive — user-facing error message, not a secret
+  const ACCESS_DENIED_MESSAGE = "このBotを利用する権限がありません。";
+  return c.json(
+    {
+      type: 4,
+      data: {
+        content: ACCESS_DENIED_MESSAGE,
+        flags: EPHEMERAL_FLAG,
+      },
+    },
+    HTTP_OK,
+  );
+}
+
+export function createAccessControl(
+  allowedUsers?: string[],
+): MiddlewareHandler {
+  return async (c, next) => {
+    const result = await checkAccessControl(c, allowedUsers);
+    if (result) return result;
+    await next();
+  };
+}

--- a/src/server/middleware/access-control.ts
+++ b/src/server/middleware/access-control.ts
@@ -5,6 +5,8 @@ import { getLogger } from "@/shared/utils/logger";
 const DISCORD_INTERACTION_TYPE_PING = 1;
 // biome-ignore lint/suspicious/noBitwiseOperators: Discord ephemeral flag requires bitwise operation
 const EPHEMERAL_FLAG = 1 << 6;
+// biome-ignore lint/security/noSecrets: false positive — user-facing error message, not a secret
+export const ACCESS_DENIED_MESSAGE = "このBotを利用する権限がありません。";
 
 export async function checkAccessControl(
   c: Context,
@@ -33,8 +35,8 @@ export function isUserAllowed(
   userId: string | undefined,
   allowedUsers?: string[],
 ): boolean {
-  const allowed = allowedUsers?.filter((u) => u.length > 0) ?? [];
-  return Boolean(userId && allowed.includes(userId));
+  if (!allowedUsers || allowedUsers.length === 0) return true;
+  return Boolean(userId && allowedUsers.includes(userId));
 }
 
 function extractUserId(parsed: Record<string, unknown>): string | undefined {
@@ -45,8 +47,6 @@ function extractUserId(parsed: Record<string, unknown>): string | undefined {
 }
 
 function ephemeralDeny(c: Context): Response {
-  // biome-ignore lint/security/noSecrets: false positive — user-facing error message, not a secret
-  const ACCESS_DENIED_MESSAGE = "このBotを利用する権限がありません。";
   return c.json(
     {
       type: 4,

--- a/src/server/routes/discord.route.test.ts
+++ b/src/server/routes/discord.route.test.ts
@@ -40,10 +40,15 @@ const mockSendMessage = vi.fn().mockResolvedValue(true);
 const mockCheckAccessControl = vi.fn().mockResolvedValue(null);
 const mockIsUserAllowed = vi.fn().mockReturnValue(true);
 
-vi.mock("@/server/middleware/access-control", () => ({
-  checkAccessControl: (...args: unknown[]) => mockCheckAccessControl(...args),
-  isUserAllowed: (...args: unknown[]) => mockIsUserAllowed(...args),
-}));
+vi.mock("@/server/middleware/access-control", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@/server/middleware/access-control")>();
+  return {
+    ...actual,
+    checkAccessControl: (...args: unknown[]) => mockCheckAccessControl(...args),
+    isUserAllowed: (...args: unknown[]) => mockIsUserAllowed(...args),
+  };
+});
 
 const { createDiscordRoute } = await import("@/server/routes/discord.route");
 

--- a/src/server/routes/discord.route.test.ts
+++ b/src/server/routes/discord.route.test.ts
@@ -27,11 +27,23 @@ vi.mock("@/sdk/discord/adapter/response.adapter", () => ({
 }));
 
 const mockParseGatewayEvent = vi.fn();
+const mockIsMentionEvent = vi.fn().mockReturnValue(false);
+
 vi.mock("@/sdk/discord/adapter/gateway-event.adapter", () => ({
   parseGatewayEvent: (...args: unknown[]) => mockParseGatewayEvent(...args),
+  isMentionEvent: (...args: unknown[]) => mockIsMentionEvent(...args),
 }));
 
 const mockHandleGatewayEvent = vi.fn();
+const mockSendMessage = vi.fn().mockResolvedValue(true);
+
+const mockCheckAccessControl = vi.fn().mockResolvedValue(null);
+const mockIsUserAllowed = vi.fn().mockReturnValue(true);
+
+vi.mock("@/server/middleware/access-control", () => ({
+  checkAccessControl: (...args: unknown[]) => mockCheckAccessControl(...args),
+  isUserAllowed: (...args: unknown[]) => mockIsUserAllowed(...args),
+}));
 
 const { createDiscordRoute } = await import("@/server/routes/discord.route");
 
@@ -48,7 +60,10 @@ function createMockMessageHandler() {
 const testDeps = {
   interactionHandler: createMockHandler(),
   messageHandler: createMockMessageHandler(),
+  discordApiClient: { sendMessage: mockSendMessage },
   botToken: "test-bot-token",
+  applicationId: "test-app-id",
+  allowedUsers: ["allowed-user-1"],
 };
 
 describe("createDiscordRoute - error cases", () => {
@@ -275,5 +290,193 @@ describe("createDiscordRoute - gateway invalid payload", () => {
     expect(res.status).toBe(400);
     expect(await res.json()).toEqual({ ok: false, error: "bad" });
     expect(mockHandleGatewayEvent).not.toHaveBeenCalled();
+  });
+});
+
+describe("createDiscordRoute - gateway mention access control", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    mockParseGatewayEvent.mockReset();
+    mockHandleGatewayEvent.mockReset();
+    mockIsMentionEvent.mockReset();
+    mockIsUserAllowed.mockReset();
+    mockSendMessage.mockReset();
+    mockLog.warn.mockReset();
+  });
+
+  it("denies mention event from disallowed user and sends deny message", async () => {
+    const event = {
+      type: "GATEWAY_MESSAGE_CREATE",
+      timestamp: 1,
+      data: { author: { id: "disallowed-user" }, channel_id: "ch-123" },
+    };
+    mockParseGatewayEvent.mockReturnValue({ ok: true, value: event });
+    mockIsMentionEvent.mockReturnValue(true);
+    mockIsUserAllowed.mockReturnValue(false);
+    mockSendMessage.mockResolvedValue(true);
+
+    const app = createDiscordRoute(testDeps);
+
+    const res = await app.request("/", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "x-discord-gateway-token": "test-bot-token",
+      },
+      body: JSON.stringify(event),
+    });
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: true });
+    expect(mockSendMessage).toHaveBeenCalledWith(
+      "ch-123",
+      "このBotを利用する権限がありません。",
+    );
+    expect(mockHandleGatewayEvent).not.toHaveBeenCalled();
+    expect(mockLog.warn).toHaveBeenCalledWith(
+      { authorId: "disallowed-user" },
+      "Gateway event denied: user not in allowed list",
+    );
+  });
+
+  it("allows mention event from allowed user", async () => {
+    const event = {
+      type: "GATEWAY_MESSAGE_CREATE",
+      timestamp: 1,
+      data: { author: { id: "allowed-user-1" }, channel_id: "ch-123" },
+    };
+    mockParseGatewayEvent.mockReturnValue({ ok: true, value: event });
+    mockIsMentionEvent.mockReturnValue(true);
+    mockIsUserAllowed.mockReturnValue(true);
+    mockHandleGatewayEvent.mockResolvedValue(undefined);
+
+    const app = createDiscordRoute(testDeps);
+
+    const res = await app.request("/", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "x-discord-gateway-token": "test-bot-token",
+      },
+      body: JSON.stringify(event),
+    });
+
+    expect(res.status).toBe(200);
+    expect(mockSendMessage).not.toHaveBeenCalled();
+    expect(mockHandleGatewayEvent).toHaveBeenCalledWith(event);
+  });
+
+  it("denies mention event without channel_id and does not send message", async () => {
+    const event = {
+      type: "GATEWAY_MESSAGE_CREATE",
+      timestamp: 1,
+      data: { author: { id: "disallowed-user" } },
+    };
+    mockParseGatewayEvent.mockReturnValue({ ok: true, value: event });
+    mockIsMentionEvent.mockReturnValue(true);
+    mockIsUserAllowed.mockReturnValue(false);
+
+    const app = createDiscordRoute(testDeps);
+
+    const res = await app.request("/", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "x-discord-gateway-token": "test-bot-token",
+      },
+      body: JSON.stringify(event),
+    });
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: true });
+    expect(mockSendMessage).not.toHaveBeenCalled();
+    expect(mockHandleGatewayEvent).not.toHaveBeenCalled();
+  });
+
+  it("skips access control for non-mention gateway event", async () => {
+    const event = {
+      type: "GATEWAY_MESSAGE_CREATE",
+      timestamp: 1,
+      data: { author: { id: "disallowed-user" }, channel_id: "ch-123" },
+    };
+    mockParseGatewayEvent.mockReturnValue({ ok: true, value: event });
+    mockIsMentionEvent.mockReturnValue(false);
+    mockHandleGatewayEvent.mockResolvedValue(undefined);
+
+    const app = createDiscordRoute(testDeps);
+
+    const res = await app.request("/", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "x-discord-gateway-token": "test-bot-token",
+      },
+      body: JSON.stringify(event),
+    });
+
+    expect(res.status).toBe(200);
+    expect(mockIsUserAllowed).not.toHaveBeenCalled();
+    expect(mockHandleGatewayEvent).toHaveBeenCalledWith(event);
+  });
+});
+
+describe("createDiscordRoute - interaction access control", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    mockCheckAccessControl.mockReset();
+    mockToDomain.mockReset();
+    mockLog.warn.mockReset();
+  });
+
+  it("returns access denied response from checkAccessControl", async () => {
+    mockCheckAccessControl.mockResolvedValue(
+      new Response(
+        JSON.stringify({ type: 4, data: { content: "deny", flags: 64 } }),
+        { status: 200 },
+      ),
+    );
+
+    const app = createDiscordRoute(testDeps);
+
+    const res = await app.request("/", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ type: 2, id: "1" }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(mockToDomain).not.toHaveBeenCalled();
+  });
+
+  it("continues to interaction handling when access is allowed", async () => {
+    mockCheckAccessControl.mockResolvedValue(null);
+    const interaction: DomainInteraction = {
+      id: "1",
+      type: "command",
+      channelId: "ch1",
+      userId: "allowed-user-1",
+      commandName: "ping",
+      raw: {},
+    };
+    mockToDomain.mockReturnValue({ ok: true, value: interaction });
+    const handler = createMockHandler();
+    vi.mocked(handler).handle = vi
+      .fn()
+      .mockResolvedValue({ type: 4, data: { content: "Pong!" } });
+
+    const app = createDiscordRoute({
+      ...testDeps,
+      interactionHandler: handler,
+    });
+
+    const res = await app.request("/", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ type: 2, id: "1", data: { name: "ping" } }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(mockToDomain).toHaveBeenCalled();
+    expect(handler.handle).toHaveBeenCalledWith(interaction);
   });
 });

--- a/src/server/routes/discord.route.ts
+++ b/src/server/routes/discord.route.ts
@@ -8,6 +8,7 @@ import {
 import { toDomain } from "@/sdk/discord/adapter/interaction.adapter";
 import { toDiscord } from "@/sdk/discord/adapter/response.adapter";
 import {
+  ACCESS_DENIED_MESSAGE,
   checkAccessControl,
   isUserAllowed,
 } from "@/server/middleware/access-control";
@@ -19,8 +20,6 @@ import {
   HTTP_UNAUTHORIZED,
 } from "@/shared/utils/http-status";
 import { getLogger } from "@/shared/utils/logger";
-
-const ACCESS_DENIED_MESSAGE = "このBotを利用する権限がありません。";
 
 export function createDiscordRoute(deps: {
   interactionHandler: InteractionHandler;

--- a/src/server/routes/discord.route.ts
+++ b/src/server/routes/discord.route.ts
@@ -1,9 +1,16 @@
 import { Hono } from "hono";
 import type { InteractionHandler } from "@/bot/handlers/interaction.handler";
 import type { MessageHandler } from "@/bot/handlers/message.handler";
-import { parseGatewayEvent } from "@/sdk/discord/adapter/gateway-event.adapter";
+import {
+  isMentionEvent,
+  parseGatewayEvent,
+} from "@/sdk/discord/adapter/gateway-event.adapter";
 import { toDomain } from "@/sdk/discord/adapter/interaction.adapter";
 import { toDiscord } from "@/sdk/discord/adapter/response.adapter";
+import {
+  checkAccessControl,
+  isUserAllowed,
+} from "@/server/middleware/access-control";
 import { verifyDiscordSignature } from "@/server/middleware/verify-discord";
 import {
   HTTP_BAD_REQUEST,
@@ -13,10 +20,17 @@ import {
 } from "@/shared/utils/http-status";
 import { getLogger } from "@/shared/utils/logger";
 
+const ACCESS_DENIED_MESSAGE = "このBotを利用する権限がありません。";
+
 export function createDiscordRoute(deps: {
   interactionHandler: InteractionHandler;
   messageHandler: MessageHandler;
+  discordApiClient: {
+    sendMessage: (channelId: string, content: string) => Promise<boolean>;
+  };
   botToken: string;
+  applicationId: string;
+  allowedUsers?: string[];
 }): Hono {
   const discord = new Hono();
   const log = getLogger();
@@ -47,12 +61,35 @@ export function createDiscordRoute(deps: {
         );
       }
 
+      const eventData = eventResult.value.data as Record<string, unknown>;
+      if (isMentionEvent(eventResult.value, deps.applicationId)) {
+        const author = eventData?.author as Record<string, unknown> | undefined;
+        const authorId = author?.id as string | undefined;
+        if (!isUserAllowed(authorId, deps.allowedUsers)) {
+          log.warn(
+            { authorId },
+            "Gateway event denied: user not in allowed list",
+          );
+          const channelId = eventData.channel_id as string | undefined;
+          if (channelId) {
+            await deps.discordApiClient.sendMessage(
+              channelId,
+              ACCESS_DENIED_MESSAGE,
+            );
+          }
+          return c.json({ ok: true }, HTTP_OK);
+        }
+      }
+
       await deps.messageHandler.handleGatewayEvent(eventResult.value);
       return c.json({ ok: true }, HTTP_OK);
     }
 
     const verifyResult = await verifyDiscordSignature(c);
     if (verifyResult) return verifyResult;
+
+    const accessResult = await checkAccessControl(c, deps.allowedUsers);
+    if (accessResult) return accessResult;
 
     const raw = await c.req.json();
     const result = toDomain(raw);


### PR DESCRIPTION
# チケット

close #38

# 概要

Discord Botに対して、許可されたユーザーのみが利用できるアクセス制御機能を追加しました。

### 変更内容

- **BotConfig**: `allowedUsers` フィールド（文字列配列、オプション）を追加し、`config.yaml` で設定可能にした
- **アクセス制御ミドルウェア**: `checkAccessControl`（Interaction用）と `isUserAllowed`（Gatewayメンション用）を新規作成
- **Discordルート**: メンションイベントとインタラクションイベントの両方でアクセス制御を適用。許可されていないユーザーには拒绝メッセージを返す
- **Bootstrap**: 新しい依存関係（`discordApiClient`, `applicationId`, `allowedUsers`）を配線

### アクセス制御の動作

- `allowedUsers` が未設定または空配列の場合、すべてのユーザーを許可
- メンションイベント: 許可されていないユーザーにはチャンネルに「このBotを利用する権限がありません。」と通知
- インタラクションイベント: 許可されていないユーザーにはephemeralメッセージで通知

# その他

resolves #38