### PR TITLE
♻️ Discordルートのリファクタリングとテスト改善

### DIFF
--- a/src/app/bootstrap.test.ts
+++ b/src/app/bootstrap.test.ts
@@ -21,6 +21,7 @@ const mockRedisDisconnect = vi.fn().mockResolvedValue(undefined);
 const mockRedisConnect = vi.fn().mockResolvedValue(undefined);
 const mockRegisterGuildCommands = vi.fn().mockResolvedValue(undefined);
 
+// biome-ignore lint/complexity/noExcessiveLinesPerFunction: mock setup with many vi.doMock calls
 function setupMocks(
   config: Record<string, unknown>,
   envOverrides?: Record<string, unknown>,

--- a/src/infrastructure/web/web-fetcher.client.test.ts
+++ b/src/infrastructure/web/web-fetcher.client.test.ts
@@ -12,7 +12,7 @@ vi.mock("@/shared/utils/logger", () => ({
 
 const JINA_BASE = "https://r.jina.ai";
 
-describe("WebFetcherClient success", () => {
+describe("WebFetcherClient fetch", () => {
   let client: WebFetcherClient;
 
   beforeEach(() => {
@@ -21,11 +21,13 @@ describe("WebFetcherClient success", () => {
   });
 
   it("fetches content via Jina Reader API", async () => {
-    const mockFetch = vi.fn().mockResolvedValue({
-      ok: true,
-      text: () => Promise.resolve("Article content here"),
-    });
-    vi.stubGlobal("fetch", mockFetch);
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        text: () => Promise.resolve("Article content here"),
+      }),
+    );
 
     const result = await client.fetchContent("https://example.com/article");
 
@@ -33,12 +35,21 @@ describe("WebFetcherClient success", () => {
     if (result.ok) {
       expect(result.value).toContain("Article content here");
     }
-    expect(mockFetch).toHaveBeenCalledWith(
+    expect(vi.mocked(fetch)).toHaveBeenCalledWith(
       `${JINA_BASE}/https://example.com/article`,
       expect.objectContaining({
         headers: { Accept: "text/plain" },
       }),
     );
+  });
+});
+
+describe("WebFetcherClient content truncation", () => {
+  let client: WebFetcherClient;
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    client = new WebFetcherClient();
   });
 
   it("truncates content exceeding max length", async () => {

--- a/src/server/middleware/access-control.test.ts
+++ b/src/server/middleware/access-control.test.ts
@@ -10,9 +10,12 @@ const mockLog = {
 
 vi.mock("@/shared/utils/logger", () => ({ getLogger: () => mockLog }));
 
-const { checkAccessControl, createAccessControl, isUserAllowed } = await import(
-  "@/server/middleware/access-control"
-);
+const {
+  ACCESS_DENIED_MESSAGE,
+  checkAccessControl,
+  createAccessControl,
+  isUserAllowed,
+} = await import("@/server/middleware/access-control");
 
 function createContext(body: string) {
   const raw = new Request("https://example.com", {
@@ -90,7 +93,7 @@ describe("checkAccessControl - denial", () => {
       {
         type: 4,
         data: {
-          content: "このBotを利用する権限がありません。",
+          content: ACCESS_DENIED_MESSAGE,
           flags: 64,
         },
       },
@@ -111,7 +114,7 @@ describe("checkAccessControl - denial", () => {
       {
         type: 4,
         data: {
-          content: "このBotを利用する権限がありません。",
+          content: ACCESS_DENIED_MESSAGE,
           flags: 64,
         },
       },
@@ -182,7 +185,7 @@ describe("createAccessControl - middleware wrapper", () => {
       {
         type: 4,
         data: {
-          content: "このBotを利用する権限がありません。",
+          content: ACCESS_DENIED_MESSAGE,
           flags: 64,
         },
       },

--- a/src/server/routes/discord.route.test.ts
+++ b/src/server/routes/discord.route.test.ts
@@ -40,9 +40,12 @@ const mockSendMessage = vi.fn().mockResolvedValue(true);
 const mockCheckAccessControl = vi.fn().mockResolvedValue(null);
 const mockIsUserAllowed = vi.fn().mockReturnValue(true);
 
+let actualAccessControl: typeof import("@/server/middleware/access-control");
+
 vi.mock("@/server/middleware/access-control", async (importOriginal) => {
   const actual =
     await importOriginal<typeof import("@/server/middleware/access-control")>();
+  actualAccessControl = actual;
   return {
     ...actual,
     checkAccessControl: (...args: unknown[]) => mockCheckAccessControl(...args),
@@ -60,6 +63,20 @@ function createMockMessageHandler() {
   return {
     handleGatewayEvent: mockHandleGatewayEvent,
   } as unknown as MessageHandler;
+}
+
+function postGatewayEvent(
+  app: ReturnType<typeof createDiscordRoute>,
+  event: unknown,
+) {
+  return app.request("/", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "x-discord-gateway-token": "test-bot-token",
+    },
+    body: JSON.stringify(event),
+  });
 }
 
 const testDeps = {
@@ -298,7 +315,7 @@ describe("createDiscordRoute - gateway invalid payload", () => {
   });
 });
 
-describe("createDiscordRoute - gateway mention access control", () => {
+describe("createDiscordRoute - gateway mention access denial", () => {
   beforeEach(() => {
     vi.restoreAllMocks();
     mockParseGatewayEvent.mockReset();
@@ -320,28 +337,48 @@ describe("createDiscordRoute - gateway mention access control", () => {
     mockIsUserAllowed.mockReturnValue(false);
     mockSendMessage.mockResolvedValue(true);
 
-    const app = createDiscordRoute(testDeps);
-
-    const res = await app.request("/", {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        "x-discord-gateway-token": "test-bot-token",
-      },
-      body: JSON.stringify(event),
-    });
+    const res = await postGatewayEvent(createDiscordRoute(testDeps), event);
 
     expect(res.status).toBe(200);
     expect(await res.json()).toEqual({ ok: true });
     expect(mockSendMessage).toHaveBeenCalledWith(
       "ch-123",
-      "このBotを利用する権限がありません。",
+      actualAccessControl.ACCESS_DENIED_MESSAGE,
     );
     expect(mockHandleGatewayEvent).not.toHaveBeenCalled();
     expect(mockLog.warn).toHaveBeenCalledWith(
       { authorId: "disallowed-user" },
       "Gateway event denied: user not in allowed list",
     );
+  });
+
+  it("denies mention event without channel_id and does not send message", async () => {
+    const event = {
+      type: "GATEWAY_MESSAGE_CREATE",
+      timestamp: 1,
+      data: { author: { id: "disallowed-user" } },
+    };
+    mockParseGatewayEvent.mockReturnValue({ ok: true, value: event });
+    mockIsMentionEvent.mockReturnValue(true);
+    mockIsUserAllowed.mockReturnValue(false);
+
+    const res = await postGatewayEvent(createDiscordRoute(testDeps), event);
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: true });
+    expect(mockSendMessage).not.toHaveBeenCalled();
+    expect(mockHandleGatewayEvent).not.toHaveBeenCalled();
+  });
+});
+
+describe("createDiscordRoute - gateway mention access allowance", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    mockParseGatewayEvent.mockReset();
+    mockHandleGatewayEvent.mockReset();
+    mockIsMentionEvent.mockReset();
+    mockIsUserAllowed.mockReset();
+    mockSendMessage.mockReset();
   });
 
   it("allows mention event from allowed user", async () => {
@@ -355,47 +392,11 @@ describe("createDiscordRoute - gateway mention access control", () => {
     mockIsUserAllowed.mockReturnValue(true);
     mockHandleGatewayEvent.mockResolvedValue(undefined);
 
-    const app = createDiscordRoute(testDeps);
-
-    const res = await app.request("/", {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        "x-discord-gateway-token": "test-bot-token",
-      },
-      body: JSON.stringify(event),
-    });
+    const res = await postGatewayEvent(createDiscordRoute(testDeps), event);
 
     expect(res.status).toBe(200);
     expect(mockSendMessage).not.toHaveBeenCalled();
     expect(mockHandleGatewayEvent).toHaveBeenCalledWith(event);
-  });
-
-  it("denies mention event without channel_id and does not send message", async () => {
-    const event = {
-      type: "GATEWAY_MESSAGE_CREATE",
-      timestamp: 1,
-      data: { author: { id: "disallowed-user" } },
-    };
-    mockParseGatewayEvent.mockReturnValue({ ok: true, value: event });
-    mockIsMentionEvent.mockReturnValue(true);
-    mockIsUserAllowed.mockReturnValue(false);
-
-    const app = createDiscordRoute(testDeps);
-
-    const res = await app.request("/", {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        "x-discord-gateway-token": "test-bot-token",
-      },
-      body: JSON.stringify(event),
-    });
-
-    expect(res.status).toBe(200);
-    expect(await res.json()).toEqual({ ok: true });
-    expect(mockSendMessage).not.toHaveBeenCalled();
-    expect(mockHandleGatewayEvent).not.toHaveBeenCalled();
   });
 
   it("skips access control for non-mention gateway event", async () => {
@@ -408,16 +409,7 @@ describe("createDiscordRoute - gateway mention access control", () => {
     mockIsMentionEvent.mockReturnValue(false);
     mockHandleGatewayEvent.mockResolvedValue(undefined);
 
-    const app = createDiscordRoute(testDeps);
-
-    const res = await app.request("/", {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        "x-discord-gateway-token": "test-bot-token",
-      },
-      body: JSON.stringify(event),
-    });
+    const res = await postGatewayEvent(createDiscordRoute(testDeps), event);
 
     expect(res.status).toBe(200);
     expect(mockIsUserAllowed).not.toHaveBeenCalled();

--- a/src/server/routes/discord.route.ts
+++ b/src/server/routes/discord.route.ts
@@ -1,3 +1,4 @@
+import type { Context } from "hono";
 import { Hono } from "hono";
 import type { InteractionHandler } from "@/bot/handlers/interaction.handler";
 import type { MessageHandler } from "@/bot/handlers/message.handler";
@@ -21,7 +22,7 @@ import {
 } from "@/shared/utils/http-status";
 import { getLogger } from "@/shared/utils/logger";
 
-export function createDiscordRoute(deps: {
+type RouteDeps = {
   interactionHandler: InteractionHandler;
   messageHandler: MessageHandler;
   discordApiClient: {
@@ -30,81 +31,96 @@ export function createDiscordRoute(deps: {
   botToken: string;
   applicationId: string;
   allowedUsers?: string[];
-}): Hono {
+};
+
+async function handleGatewayEvent(
+  c: Context,
+  raw: unknown,
+  deps: RouteDeps,
+  log: ReturnType<typeof getLogger>,
+): Promise<Response> {
+  const gatewayToken = c.req.header("x-discord-gateway-token");
+  if (gatewayToken !== deps.botToken) {
+    return c.json({ error: "Invalid gateway token" }, HTTP_UNAUTHORIZED);
+  }
+
+  log.debug(
+    { eventType: (raw as Record<string, unknown>)?.type },
+    "Gateway event received",
+  );
+  const eventResult = parseGatewayEvent(raw);
+
+  if (!eventResult.ok) {
+    log.warn(
+      { error: eventResult.error.message },
+      "Invalid gateway event payload",
+    );
+    return c.json(
+      { ok: false, error: eventResult.error.message },
+      HTTP_BAD_REQUEST,
+    );
+  }
+
+  const eventData = eventResult.value.data as Record<string, unknown>;
+  if (isMentionEvent(eventResult.value, deps.applicationId)) {
+    const author = eventData?.author as Record<string, unknown> | undefined;
+    const authorId = author?.id as string | undefined;
+    if (!isUserAllowed(authorId, deps.allowedUsers)) {
+      log.warn({ authorId }, "Gateway event denied: user not in allowed list");
+      const channelId = eventData.channel_id as string | undefined;
+      if (channelId) {
+        await deps.discordApiClient.sendMessage(
+          channelId,
+          ACCESS_DENIED_MESSAGE,
+        );
+      }
+      return c.json({ ok: true }, HTTP_OK);
+    }
+  }
+
+  await deps.messageHandler.handleGatewayEvent(eventResult.value);
+  return c.json({ ok: true }, HTTP_OK);
+}
+
+async function handleInteraction(
+  c: Context,
+  deps: RouteDeps,
+  log: ReturnType<typeof getLogger>,
+): Promise<Response> {
+  const verifyResult = await verifyDiscordSignature(c);
+  if (verifyResult) return verifyResult;
+
+  const accessResult = await checkAccessControl(c, deps.allowedUsers);
+  if (accessResult) return accessResult;
+
+  const raw = await c.req.json();
+  const result = toDomain(raw);
+
+  if (!result.ok) {
+    log.warn({ error: result.error.message }, "Invalid interaction payload");
+    return c.json({ error: result.error.message }, HTTP_BAD_REQUEST);
+  }
+
+  try {
+    const response = await deps.interactionHandler.handle(result.value);
+    return c.json(toDiscord(response), HTTP_OK);
+  } catch {
+    log.error("Interaction handler error");
+    return c.json({ error: "Internal error" }, HTTP_INTERNAL_SERVER_ERROR);
+  }
+}
+
+export function createDiscordRoute(deps: RouteDeps): Hono {
   const discord = new Hono();
   const log = getLogger();
 
   discord.post("/", async (c) => {
     const gatewayToken = c.req.header("x-discord-gateway-token");
-
     if (gatewayToken) {
-      if (gatewayToken !== deps.botToken) {
-        return c.json({ error: "Invalid gateway token" }, HTTP_UNAUTHORIZED);
-      }
-
       const raw = await c.req.json();
-      log.debug(
-        { eventType: (raw as Record<string, unknown>)?.type },
-        "Gateway event received",
-      );
-      const eventResult = parseGatewayEvent(raw);
-
-      if (!eventResult.ok) {
-        log.warn(
-          { error: eventResult.error.message },
-          "Invalid gateway event payload",
-        );
-        return c.json(
-          { ok: false, error: eventResult.error.message },
-          HTTP_BAD_REQUEST,
-        );
-      }
-
-      const eventData = eventResult.value.data as Record<string, unknown>;
-      if (isMentionEvent(eventResult.value, deps.applicationId)) {
-        const author = eventData?.author as Record<string, unknown> | undefined;
-        const authorId = author?.id as string | undefined;
-        if (!isUserAllowed(authorId, deps.allowedUsers)) {
-          log.warn(
-            { authorId },
-            "Gateway event denied: user not in allowed list",
-          );
-          const channelId = eventData.channel_id as string | undefined;
-          if (channelId) {
-            await deps.discordApiClient.sendMessage(
-              channelId,
-              ACCESS_DENIED_MESSAGE,
-            );
-          }
-          return c.json({ ok: true }, HTTP_OK);
-        }
-      }
-
-      await deps.messageHandler.handleGatewayEvent(eventResult.value);
-      return c.json({ ok: true }, HTTP_OK);
+      return handleGatewayEvent(c, raw, deps, log);
     }
-
-    const verifyResult = await verifyDiscordSignature(c);
-    if (verifyResult) return verifyResult;
-
-    const accessResult = await checkAccessControl(c, deps.allowedUsers);
-    if (accessResult) return accessResult;
-
-    const raw = await c.req.json();
-    const result = toDomain(raw);
-
-    if (!result.ok) {
-      log.warn({ error: result.error.message }, "Invalid interaction payload");
-      return c.json({ error: result.error.message }, HTTP_BAD_REQUEST);
-    }
-
-    try {
-      const response = await deps.interactionHandler.handle(result.value);
-      return c.json(toDiscord(response), HTTP_OK);
-    } catch {
-      log.error("Interaction handler error");
-      return c.json({ error: "Internal error" }, HTTP_INTERNAL_SERVER_ERROR);
-    }
+    return handleInteraction(c, deps, log);
   });
 
   return discord;


### PR DESCRIPTION
# チケット

close #52

# 概要

Discordルートハンドラの可読性・保守性を向上させるリファクタリングと、テストコードの改善を行いました。

### 本番コード
- `discord.route.ts` の単一ルートハンドラを `handleGatewayEvent` / `handleInteraction` の2つの関数に分割
- 依存関係の型を `RouteDeps` として型エイリアス化

### テストコード
- `access-control.test.ts` / `discord.route.test.ts` でハードコードしていた拒否メッセージを `ACCESS_DENIED_MESSAGE` 定数に置き換え
- `discord.route.test.ts` のゲートウェイアクセス制御テストを拒否/許可でdescribeブロックを分割し、`postGatewayEvent` ヘルパーを抽出
- `web-fetcher.client.test.ts` のdescribeブロックを機能単位に分割
- `bootstrap.test.ts` にbiome-ignoreコメントを追加

# その他

resolves #52