### PR TITLE
♻️ CodexClientからOpenAIClientへの移行

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "@openai/codex-sdk": "^0.125.0",
     "discord-api-types": "^0.38.47",
     "hono": "^4.12.15",
+    "openai": "^6.35.0",
     "pino": "^10.3.1",
     "redis": "^5.12.1",
     "yaml": "^2.8.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,6 +29,9 @@ importers:
       hono:
         specifier: ^4.12.15
         version: 4.12.15
+      openai:
+        specifier: ^6.35.0
+        version: 6.35.0(ws@8.20.0)(zod@4.3.6)
       pino:
         specifier: ^10.3.1
         version: 10.3.1
@@ -1215,6 +1218,18 @@ packages:
 
   once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
+
+  openai@6.35.0:
+    resolution: {integrity: sha512-L/skwIGnt5xQZHb0UfTu9uAUKbis3ehKypOuJKi20QvG7UStV6C8IC3myGYHcdiF4kms/bAvOJ9UqqNWqi8x/Q==}
+    hasBin: true
+    peerDependencies:
+      ws: ^8.18.0
+      zod: ^3.25 || ^4.0
+    peerDependenciesMeta:
+      ws:
+        optional: true
+      zod:
+        optional: true
 
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
@@ -2609,6 +2624,11 @@ snapshots:
   once@1.4.0:
     dependencies:
       wrappy: 1.0.2
+
+  openai@6.35.0(ws@8.20.0)(zod@4.3.6):
+    optionalDependencies:
+      ws: 8.20.0
+      zod: 4.3.6
 
   pathe@2.0.3: {}
 

--- a/src/ai/client/openai.client.test.ts
+++ b/src/ai/client/openai.client.test.ts
@@ -1,0 +1,178 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockCreate = vi.fn();
+const mockOpenAIConstructor = vi.fn();
+
+vi.mock("openai", () => ({
+  default: vi
+    .fn()
+    // biome-ignore lint/complexity/useArrowFunction: constructor mock requires function expression
+    .mockImplementation(function (options?: unknown) {
+      mockOpenAIConstructor(options);
+      return {
+        chat: {
+          completions: {
+            create: mockCreate,
+          },
+        },
+      };
+    }),
+}));
+
+async function createClient(
+  apiKey = "test-api-key",
+  options?: { baseUrl?: string; model?: string },
+) {
+  const { OpenAIClient } = await import("./openai.client");
+  return new OpenAIClient(apiKey, options);
+}
+
+describe("OpenAIClient constructor", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("passes apiKey to OpenAI constructor", async () => {
+    await createClient("my-key");
+
+    expect(mockOpenAIConstructor).toHaveBeenCalledWith({
+      apiKey: "my-key",
+      baseURL: undefined,
+      defaultHeaders: { "User-Agent": "discord-codex/1.0" },
+    });
+  });
+
+  it("passes baseUrl as baseURL to OpenAI constructor", async () => {
+    await createClient("my-key", { baseUrl: "https://custom.api" });
+
+    expect(mockOpenAIConstructor).toHaveBeenCalledWith({
+      apiKey: "my-key",
+      baseURL: "https://custom.api",
+      defaultHeaders: { "User-Agent": "discord-codex/1.0" },
+    });
+  });
+
+  it("passes model option and uses it in create call", async () => {
+    mockCreate.mockResolvedValue({
+      choices: [{ message: { content: "Response" } }],
+      usage: null,
+    });
+
+    const client = await createClient("my-key", { model: "custom-model" });
+    await client.chat([{ role: "user", content: "Hello" }]);
+
+    expect(mockCreate).toHaveBeenCalledWith(
+      expect.objectContaining({ model: "custom-model" }),
+    );
+  });
+
+  it("defaults model to codex-mini when not provided", async () => {
+    mockCreate.mockResolvedValue({
+      choices: [{ message: { content: "Response" } }],
+      usage: null,
+    });
+
+    const client = await createClient("my-key");
+    await client.chat([{ role: "user", content: "Hello" }]);
+
+    expect(mockCreate).toHaveBeenCalledWith(
+      expect.objectContaining({ model: "codex-mini" }),
+    );
+  });
+});
+
+describe("OpenAIClient chat successful call", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockCreate.mockResolvedValue({
+      choices: [{ message: { content: "Hello from AI" } }],
+      usage: {
+        prompt_tokens: 10,
+        completion_tokens: 5,
+        total_tokens: 15,
+      },
+    });
+  });
+
+  it("calls chat.completions.create with messages", async () => {
+    const client = await createClient();
+    const messages = [
+      { role: "system" as const, content: "You are helpful" },
+      { role: "user" as const, content: "Hello" },
+    ];
+    const result = await client.chat(messages);
+
+    expect(mockCreate).toHaveBeenCalledWith({
+      model: "codex-mini",
+      messages,
+    });
+    expect(result.response).toBe("Hello from AI");
+  });
+
+  it("returns usage from API response", async () => {
+    const client = await createClient();
+    const result = await client.chat([{ role: "user", content: "Hello" }]);
+
+    expect(result.usage).toEqual({
+      prompt_tokens: 10,
+      completion_tokens: 5,
+      total_tokens: 15,
+    });
+  });
+});
+
+describe("OpenAIClient chat error handling", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("propagates OpenAI API error", async () => {
+    mockCreate.mockRejectedValue(new Error("API internal error"));
+
+    const client = await createClient();
+    await expect(
+      client.chat([{ role: "user", content: "Hello" }]),
+    ).rejects.toThrow("API internal error");
+  });
+
+  it("throws when no response content", async () => {
+    mockCreate.mockResolvedValue({
+      choices: [{ message: { content: null } }],
+      usage: null,
+    });
+
+    const client = await createClient();
+    await expect(
+      client.chat([{ role: "user", content: "Hello" }]),
+    ).rejects.toThrow("No response content from OpenAI API");
+  });
+
+  it("throws when choices array is empty", async () => {
+    mockCreate.mockResolvedValue({
+      choices: [],
+      usage: null,
+    });
+
+    const client = await createClient();
+    await expect(
+      client.chat([{ role: "user", content: "Hello" }]),
+    ).rejects.toThrow("No response content from OpenAI API");
+  });
+});
+
+describe("OpenAIClient chat usage null", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockCreate.mockResolvedValue({
+      choices: [{ message: { content: "No usage" } }],
+      usage: null,
+    });
+  });
+
+  it("handles null usage", async () => {
+    const client = await createClient();
+    const result = await client.chat([{ role: "user", content: "Hello" }]);
+    expect(result.usage).toBeNull();
+    expect(result.response).toBe("No usage");
+  });
+});

--- a/src/ai/client/openai.client.ts
+++ b/src/ai/client/openai.client.ts
@@ -1,0 +1,42 @@
+import OpenAI from "openai";
+
+export interface ChatResult {
+  response: string;
+  usage: OpenAI.Completions.CompletionUsage | null;
+}
+
+export interface ChatMessage {
+  role: "system" | "user" | "assistant";
+  content: string;
+}
+
+export class OpenAIClient {
+  private openai: OpenAI;
+  private model: string;
+
+  constructor(apiKey: string, options?: { baseUrl?: string; model?: string }) {
+    this.openai = new OpenAI({
+      apiKey,
+      baseURL: options?.baseUrl,
+      defaultHeaders: { "User-Agent": "discord-codex/1.0" },
+    });
+    this.model = options?.model ?? "codex-mini";
+  }
+
+  async chat(messages: ChatMessage[]): Promise<ChatResult> {
+    const response = await this.openai.chat.completions.create({
+      model: this.model,
+      messages,
+    });
+
+    const content = response.choices[0]?.message?.content;
+    if (!content) {
+      throw new Error("No response content from OpenAI API");
+    }
+
+    return {
+      response: content,
+      usage: response.usage ?? null,
+    };
+  }
+}

--- a/src/ai/services/ai.service.test.ts
+++ b/src/ai/services/ai.service.test.ts
@@ -5,9 +5,9 @@ const mockRedisGet = vi.fn();
 const mockRedisSet = vi.fn();
 const mockRedisDelete = vi.fn();
 
-vi.mock("../client/codex.client", () => ({
+vi.mock("../client/openai.client", () => ({
   // biome-ignore lint/complexity/useArrowFunction: constructor mock requires function expression
-  CodexClient: vi.fn().mockImplementation(function () {
+  OpenAIClient: vi.fn().mockImplementation(function () {
     return { chat: mockChat };
   }),
 }));
@@ -33,10 +33,10 @@ vi.mock("@/shared/utils/logger", () => ({
 
 async function createService() {
   const { AIService } = await import("./ai.service");
-  const { CodexClient } = await import("../client/codex.client");
+  const { OpenAIClient } = await import("../client/openai.client");
   const { RedisClient } = await import("@/infrastructure/redis/redis.client");
   return new AIService(
-    new (CodexClient as ReturnType<typeof vi.fn>)(),
+    new (OpenAIClient as ReturnType<typeof vi.fn>)(),
     new (RedisClient as ReturnType<typeof vi.fn>)(),
   );
 }
@@ -47,13 +47,12 @@ describe("AIService chat new conversation", () => {
     mockRedisGet.mockResolvedValue(null);
     mockChat.mockResolvedValue({
       response: "AI response",
-      threadId: "thread-abc",
       usage: null,
     });
     mockRedisSet.mockResolvedValue(undefined);
   });
 
-  it("creates new thread when no mapping exists", async () => {
+  it("starts with system prompt when no Redis history", async () => {
     const service = await createService();
     const result = await service.chat("channel-1", "Hello");
     expect(result.ok).toBe(true);
@@ -62,41 +61,73 @@ describe("AIService chat new conversation", () => {
     }
   });
 
-  it("saves thread mapping with TTL", async () => {
+  it("saves JSON message history to Redis with TTL", async () => {
     const service = await createService();
     await service.chat("channel-1", "Hello");
     expect(mockRedisSet).toHaveBeenCalledWith(
-      "thread:channel-1",
-      "thread-abc",
+      "messages:channel-1",
+      expect.any(String),
       { ttlMs: 86400000 },
     );
+    const savedValue = JSON.parse(
+      mockRedisSet.mock.calls[0][1] as string,
+    ) as Array<{ role: string; content: string }>;
+    expect(savedValue).toHaveLength(3);
+    expect(savedValue[0].role).toBe("system");
+    expect(savedValue[1].role).toBe("user");
+    expect(savedValue[1].content).toBe("Hello");
+    expect(savedValue[2].role).toBe("assistant");
+    expect(savedValue[2].content).toBe("AI response");
   });
 
-  it("passes null threadId to client when no mapping", async () => {
+  it("passes messages array with system prompt to client.chat", async () => {
     const service = await createService();
     await service.chat("channel-1", "Hello");
-    expect(mockChat).toHaveBeenCalledWith(null, expect.any(String));
+    expect(mockChat).toHaveBeenCalledWith(
+      expect.arrayContaining([
+        expect.objectContaining({
+          role: "system",
+          content: expect.stringContaining("AIアシスタント"),
+        }),
+        expect.objectContaining({ role: "user", content: "Hello" }),
+      ]),
+    );
   });
 });
 
 describe("AIService chat existing conversation", () => {
+  const existingHistory = JSON.stringify([
+    { role: "system", content: "You are helpful" },
+    { role: "user", content: "First message" },
+    { role: "assistant", content: "First response" },
+  ]);
+
   beforeEach(() => {
     vi.clearAllMocks();
-    mockRedisGet.mockResolvedValue("thread-existing");
+    mockRedisGet.mockResolvedValue(existingHistory);
     mockChat.mockResolvedValue({
       response: "Continued response",
-      threadId: "thread-existing",
       usage: null,
     });
     mockRedisSet.mockResolvedValue(undefined);
   });
 
-  it("resumes existing thread from Redis mapping", async () => {
+  it("appends user message to existing history", async () => {
     const service = await createService();
     const result = await service.chat("channel-2", "Continue");
     expect(mockChat).toHaveBeenCalledWith(
-      "thread-existing",
-      expect.any(String),
+      expect.arrayContaining([
+        expect.objectContaining({ role: "system", content: "You are helpful" }),
+        expect.objectContaining({
+          role: "user",
+          content: "First message",
+        }),
+        expect.objectContaining({
+          role: "assistant",
+          content: "First response",
+        }),
+        expect.objectContaining({ role: "user", content: "Continue" }),
+      ]),
     );
     expect(result.ok).toBe(true);
     if (result.ok) {
@@ -104,10 +135,15 @@ describe("AIService chat existing conversation", () => {
     }
   });
 
-  it("sends only user message without system prompt on resume", async () => {
+  it("appends assistant response and saves full history", async () => {
     const service = await createService();
     await service.chat("channel-2", "Continue");
-    expect(mockChat).toHaveBeenCalledWith("thread-existing", "Continue");
+    const savedValue = JSON.parse(
+      mockRedisSet.mock.calls[0][1] as string,
+    ) as Array<{ role: string; content: string }>;
+    expect(savedValue).toHaveLength(5);
+    expect(savedValue[4].role).toBe("assistant");
+    expect(savedValue[4].content).toBe("Continued response");
   });
 });
 
@@ -139,12 +175,12 @@ describe("AIService chat error handling Redis get", () => {
   });
 });
 
-describe("AIService chat error handling Codex", () => {
+describe("AIService chat error handling OpenAI", () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
-  it("returns ExternalServiceError for Codex on client failure", async () => {
+  it("returns ExternalServiceError for OpenAI on client failure", async () => {
     mockRedisGet.mockResolvedValue(null);
     mockChat.mockRejectedValue(new Error("API rate limit"));
     const service = await createService();
@@ -152,12 +188,12 @@ describe("AIService chat error handling Codex", () => {
     expect(result.ok).toBe(false);
     if (!result.ok) {
       expect(result.error.name).toBe("ExternalServiceError");
-      expect(result.error.message).toContain("Codex");
+      expect(result.error.message).toContain("OpenAI");
       expect(result.error.message).toContain("API rate limit");
     }
   });
 
-  it("handles non-Error thrown value from Codex", async () => {
+  it("handles non-Error thrown value from OpenAI", async () => {
     mockRedisGet.mockResolvedValue(null);
     mockChat.mockRejectedValue("string error");
     const service = await createService();
@@ -178,7 +214,6 @@ describe("AIService chat error handling Redis set", () => {
     mockRedisGet.mockResolvedValue(null);
     mockChat.mockResolvedValue({
       response: "AI response",
-      threadId: "thread-abc",
       usage: null,
     });
     mockRedisSet.mockRejectedValue(new Error("write failed"));
@@ -196,7 +231,6 @@ describe("AIService chat error handling Redis set", () => {
     mockRedisGet.mockResolvedValue(null);
     mockChat.mockResolvedValue({
       response: "AI response",
-      threadId: "thread-abc",
       usage: null,
     });
     mockRedisSet.mockRejectedValue(99);
@@ -215,18 +249,21 @@ describe("AIService chat includes system prompt", () => {
     mockRedisGet.mockResolvedValue(null);
     mockChat.mockResolvedValue({
       response: "AI response",
-      threadId: "thread-sys",
       usage: null,
     });
     mockRedisSet.mockResolvedValue(undefined);
   });
 
-  it("includes system prompt in client input", async () => {
+  it("includes system prompt in messages array", async () => {
     const service = await createService();
     await service.chat("channel-sys", "Hello");
     expect(mockChat).toHaveBeenCalledWith(
-      null,
-      expect.stringContaining("AIアシスタント"),
+      expect.arrayContaining([
+        expect.objectContaining({
+          role: "system",
+          content: expect.stringContaining("AIアシスタント"),
+        }),
+      ]),
     );
   });
 });
@@ -242,7 +279,6 @@ describe("AIService chat boundary 2000 chars", () => {
     const exactResponse = "a".repeat(2000);
     mockChat.mockResolvedValue({
       response: exactResponse,
-      threadId: "thread-2000",
       usage: null,
     });
     const service = await createService();
@@ -258,7 +294,6 @@ describe("AIService chat boundary 2000 chars", () => {
     const overResponse = "a".repeat(2001);
     mockChat.mockResolvedValue({
       response: overResponse,
-      threadId: "thread-2001",
       usage: null,
     });
     const service = await createService();
@@ -278,7 +313,6 @@ describe("AIService chat long response", () => {
     const longResponse = "a".repeat(3000);
     mockChat.mockResolvedValue({
       response: longResponse,
-      threadId: "thread-long",
       usage: null,
     });
     mockRedisSet.mockResolvedValue(undefined);
@@ -301,10 +335,10 @@ describe("AIService resetConversation", () => {
     mockRedisDelete.mockResolvedValue(undefined);
   });
 
-  it("deletes thread mapping from Redis", async () => {
+  it("deletes messages key from Redis", async () => {
     const service = await createService();
     await service.resetConversation("channel-5");
-    expect(mockRedisDelete).toHaveBeenCalledWith("thread:channel-5");
+    expect(mockRedisDelete).toHaveBeenCalledWith("messages:channel-5");
   });
 
   it("propagates error when redis.delete fails", async () => {
@@ -316,51 +350,56 @@ describe("AIService resetConversation", () => {
   });
 });
 
-describe("AIService chat empty thread ID from Redis", () => {
+describe("AIService chat empty history from Redis", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockRedisGet.mockResolvedValue("");
     mockChat.mockResolvedValue({
-      response: "New thread response",
-      threadId: "thread-new",
+      response: "New response",
       usage: null,
     });
     mockRedisSet.mockResolvedValue(undefined);
   });
 
-  it("starts new thread when Redis returns empty string", async () => {
+  it("starts fresh when Redis returns empty string", async () => {
     const service = await createService();
     await service.chat("channel-empty", "Hello");
     expect(mockChat).toHaveBeenCalledWith(
-      "",
-      expect.stringContaining("AIアシスタント"),
+      expect.arrayContaining([
+        expect.objectContaining({
+          role: "system",
+          content: expect.stringContaining("AIアシスタント"),
+        }),
+        expect.objectContaining({ role: "user", content: "Hello" }),
+      ]),
     );
   });
 });
 
-describe("AIService linkThreadChannel", () => {
+describe("AIService linkThreadChannel success", () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
-  it("copies thread mapping to thread channel with TTL", async () => {
-    mockRedisGet.mockResolvedValue("thread-abc");
+  it("copies message history to thread channel with TTL", async () => {
+    const history = JSON.stringify([
+      { role: "system", content: "You are helpful" },
+      { role: "user", content: "Hello" },
+      { role: "assistant", content: "Hi" },
+    ]);
+    mockRedisGet.mockResolvedValue(history);
     mockRedisSet.mockResolvedValue(undefined);
     const service = await createService();
 
     await service.linkThreadChannel("channel-orig", "thread-ch");
 
-    expect(mockRedisGet).toHaveBeenCalledWith("thread:channel-orig");
-    expect(mockRedisSet).toHaveBeenCalledWith(
-      "thread:thread-ch",
-      "thread-abc",
-      {
-        ttlMs: 86400000,
-      },
-    );
+    expect(mockRedisGet).toHaveBeenCalledWith("messages:channel-orig");
+    expect(mockRedisSet).toHaveBeenCalledWith("messages:thread-ch", history, {
+      ttlMs: 86400000,
+    });
   });
 
-  it("does not call redis.set when original channel has no thread mapping", async () => {
+  it("does not call redis.set when original channel has no history", async () => {
     mockRedisGet.mockResolvedValue(null);
     const service = await createService();
 
@@ -369,13 +408,19 @@ describe("AIService linkThreadChannel", () => {
     expect(mockRedisSet).not.toHaveBeenCalled();
   });
 
-  it("does not call redis.set when thread ID is empty string", async () => {
+  it("does not call redis.set when history is empty string", async () => {
     mockRedisGet.mockResolvedValue("");
     const service = await createService();
 
     await service.linkThreadChannel("channel-orig", "thread-ch");
 
     expect(mockRedisSet).not.toHaveBeenCalled();
+  });
+});
+
+describe("AIService linkThreadChannel error", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
   });
 
   it("propagates error when redis.get fails", async () => {
@@ -388,7 +433,9 @@ describe("AIService linkThreadChannel", () => {
   });
 
   it("propagates error when redis.set fails", async () => {
-    mockRedisGet.mockResolvedValue("thread-abc");
+    mockRedisGet.mockResolvedValue(
+      JSON.stringify([{ role: "system", content: "test" }]),
+    );
     mockRedisSet.mockRejectedValue(new Error("write error"));
     const service = await createService();
 

--- a/src/ai/services/ai.service.test.ts
+++ b/src/ai/services/ai.service.test.ts
@@ -444,3 +444,91 @@ describe("AIService linkThreadChannel error", () => {
     ).rejects.toThrow("write error");
   });
 });
+
+describe("AIService chat message truncation at MAX_MESSAGES", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  function buildHistory(messageCount: number): string {
+    const messages: Array<{ role: string; content: string }> = [
+      { role: "system", content: "System prompt" },
+    ];
+    for (let i = 1; i < messageCount; i++) {
+      messages.push({
+        role: i % 2 === 1 ? "user" : "assistant",
+        content: `Message ${i}`,
+      });
+    }
+    return JSON.stringify(messages);
+  }
+
+  it("truncates old messages when history exceeds 50", async () => {
+    mockRedisGet.mockResolvedValue(buildHistory(51));
+    mockChat.mockResolvedValue({ response: "Truncated", usage: null });
+    mockRedisSet.mockResolvedValue(undefined);
+
+    const service = await createService();
+    await service.chat("channel-trunc", "New message");
+
+    const saved = JSON.parse(mockRedisSet.mock.calls[0][1] as string) as Array<{
+      role: string;
+      content: string;
+    }>;
+    // 50 (truncated) + 1 (assistant response) = 51 saved
+    expect(saved).toHaveLength(51);
+    expect(saved[0].role).toBe("system");
+    // Early messages removed: Message 1 & 2 truncated, Message 3 is now index 1
+    expect(saved[1].content).toBe("Message 3");
+    expect(saved[49].role).toBe("user");
+    expect(saved[49].content).toBe("New message");
+    expect(saved[50].role).toBe("assistant");
+    expect(saved[50].content).toBe("Truncated");
+  });
+
+  it("does not truncate when total is exactly 50 before assistant", async () => {
+    mockRedisGet.mockResolvedValue(buildHistory(49));
+    mockChat.mockResolvedValue({ response: "Exact", usage: null });
+    mockRedisSet.mockResolvedValue(undefined);
+
+    const service = await createService();
+    await service.chat("channel-exact", "New message");
+
+    const saved = JSON.parse(mockRedisSet.mock.calls[0][1] as string) as Array<{
+      role: string;
+      content: string;
+    }>;
+    // 49 (from Redis) + 1 (user) + 1 (assistant) = 51, no truncation
+    expect(saved).toHaveLength(51);
+    expect(saved[1].content).toBe("Message 1");
+    expect(saved[49].content).toBe("New message");
+    expect(saved[50].content).toBe("Exact");
+  });
+});
+
+describe("AIService chat invalid JSON in Redis", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRedisGet.mockResolvedValue("invalid json{");
+    mockChat.mockResolvedValue({
+      response: "Fallback response",
+      usage: null,
+    });
+    mockRedisSet.mockResolvedValue(undefined);
+  });
+
+  it("falls back to system prompt when stored JSON is invalid", async () => {
+    const service = await createService();
+    await service.chat("channel-bad-json", "Hello");
+
+    expect(mockChat).toHaveBeenCalledWith(
+      expect.arrayContaining([
+        expect.objectContaining({
+          role: "system",
+          content: expect.stringContaining("AIアシスタント"),
+        }),
+        expect.objectContaining({ role: "user", content: "Hello" }),
+      ]),
+    );
+  });
+});

--- a/src/ai/services/ai.service.ts
+++ b/src/ai/services/ai.service.ts
@@ -16,13 +16,9 @@ export class AIService {
 
   async chat(channelId: string, userMessage: string): Promise<Result<string>> {
     let messages: ChatMessage[];
+    let stored: string | null;
     try {
-      const stored = await this.redis.get(`${MESSAGES_KEY_PREFIX}${channelId}`);
-      if (stored) {
-        messages = JSON.parse(stored) as ChatMessage[];
-      } else {
-        messages = [{ role: "system", content: buildSystemPrompt() }];
-      }
+      stored = await this.redis.get(`${MESSAGES_KEY_PREFIX}${channelId}`);
     } catch (e) {
       return err(
         new ExternalServiceError(
@@ -32,7 +28,22 @@ export class AIService {
       );
     }
 
+    try {
+      if (stored) {
+        messages = JSON.parse(stored) as ChatMessage[];
+      } else {
+        messages = [{ role: "system", content: buildSystemPrompt() }];
+      }
+    } catch {
+      messages = [{ role: "system", content: buildSystemPrompt() }];
+    }
+
     messages.push({ role: "user", content: userMessage });
+
+    const MAX_MESSAGES = 50;
+    if (messages.length > MAX_MESSAGES) {
+      messages = [messages[0], ...messages.slice(-(MAX_MESSAGES - 1))];
+    }
 
     let responseContent: string;
     try {

--- a/src/ai/services/ai.service.ts
+++ b/src/ai/services/ai.service.ts
@@ -3,19 +3,26 @@ import { ExternalServiceError } from "@/shared/types/errors";
 import { err, ok, type Result } from "@/shared/types/result";
 import { DEFAULT_TTL_MS } from "@/shared/utils/constants";
 import { formatForDiscord } from "@/shared/utils/format";
-import type { ChatResult, CodexClient } from "../client/codex.client";
+import type { ChatMessage, OpenAIClient } from "../client/openai.client";
 import { buildSystemPrompt } from "../prompts/system";
+
+const MESSAGES_KEY_PREFIX = "messages:";
 
 export class AIService {
   constructor(
-    private client: CodexClient,
+    private client: OpenAIClient,
     private redis: RedisClient,
   ) {}
 
   async chat(channelId: string, userMessage: string): Promise<Result<string>> {
-    let threadId: string | null;
+    let messages: ChatMessage[];
     try {
-      threadId = await this.redis.get(`thread:${channelId}`);
+      const stored = await this.redis.get(`${MESSAGES_KEY_PREFIX}${channelId}`);
+      if (stored) {
+        messages = JSON.parse(stored) as ChatMessage[];
+      } else {
+        messages = [{ role: "system", content: buildSystemPrompt() }];
+      }
     } catch (e) {
       return err(
         new ExternalServiceError(
@@ -25,25 +32,29 @@ export class AIService {
       );
     }
 
-    let result: ChatResult;
+    messages.push({ role: "user", content: userMessage });
+
+    let responseContent: string;
     try {
-      const input = threadId
-        ? userMessage
-        : `${buildSystemPrompt()}\n\n---\n\n${userMessage}`;
-      result = await this.client.chat(threadId, input);
+      const result = await this.client.chat(messages);
+      responseContent = result.response;
     } catch (e) {
       return err(
         new ExternalServiceError(
-          "Codex",
+          "OpenAI",
           e instanceof Error ? e.message : String(e),
         ),
       );
     }
 
+    messages.push({ role: "assistant", content: responseContent });
+
     try {
-      await this.redis.set(`thread:${channelId}`, result.threadId, {
-        ttlMs: DEFAULT_TTL_MS,
-      });
+      await this.redis.set(
+        `${MESSAGES_KEY_PREFIX}${channelId}`,
+        JSON.stringify(messages),
+        { ttlMs: DEFAULT_TTL_MS },
+      );
     } catch (e) {
       return err(
         new ExternalServiceError(
@@ -53,20 +64,22 @@ export class AIService {
       );
     }
 
-    return ok(formatForDiscord(result.response));
+    return ok(formatForDiscord(responseContent));
   }
 
   async resetConversation(channelId: string): Promise<void> {
-    await this.redis.delete(`thread:${channelId}`);
+    await this.redis.delete(`${MESSAGES_KEY_PREFIX}${channelId}`);
   }
 
   async linkThreadChannel(
     originalChannelId: string,
     threadChannelId: string,
   ): Promise<void> {
-    const threadId = await this.redis.get(`thread:${originalChannelId}`);
-    if (threadId) {
-      await this.redis.set(`thread:${threadChannelId}`, threadId, {
+    const stored = await this.redis.get(
+      `${MESSAGES_KEY_PREFIX}${originalChannelId}`,
+    );
+    if (stored) {
+      await this.redis.set(`${MESSAGES_KEY_PREFIX}${threadChannelId}`, stored, {
         ttlMs: DEFAULT_TTL_MS,
       });
     }

--- a/src/ai/services/summary.service.test.ts
+++ b/src/ai/services/summary.service.test.ts
@@ -2,7 +2,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { WebFetcherClient } from "@/infrastructure/web/web-fetcher.client";
 import { ExternalServiceError } from "@/shared/types/errors";
 import { err, ok } from "@/shared/types/result";
-import type { ChatResult, CodexClient } from "../client/codex.client";
+import type { ChatResult, OpenAIClient } from "../client/openai.client";
 import { SummaryService } from "./summary.service";
 
 vi.mock("@/shared/utils/logger", () => ({
@@ -14,15 +14,14 @@ vi.mock("@/shared/utils/logger", () => ({
   }),
 }));
 
-function createMockCodexClient(response: string): CodexClient {
+function createMockOpenAIClient(response: string): OpenAIClient {
   const chatResult: ChatResult = {
     response,
-    threadId: "thread-123",
     usage: null,
   };
   return {
     chat: vi.fn().mockResolvedValue(chatResult),
-  } as unknown as CodexClient;
+  } as unknown as OpenAIClient;
 }
 
 function createMockWebFetcher(results: Map<string, string>): WebFetcherClient {
@@ -45,7 +44,7 @@ describe("SummaryService", () => {
 
   it(// biome-ignore lint/security/noSecrets: test description, not a secret
   "URL一覧を渡して要約結果を返す", async () => {
-    const client = createMockCodexClient("AI summary");
+    const client = createMockOpenAIClient("AI summary");
     const fetcher = createMockWebFetcher(
       new Map([["https://example.com", "page content"]]),
     );
@@ -59,7 +58,7 @@ describe("SummaryService", () => {
   });
 
   it("fetches content before calling AI", async () => {
-    const client = createMockCodexClient("response");
+    const client = createMockOpenAIClient("response");
     const fetcher = createMockWebFetcher(
       new Map([["https://example.com", "fetched text"]]),
     );
@@ -67,12 +66,14 @@ describe("SummaryService", () => {
 
     await service.summarize(["https://example.com"]);
     expect(fetcher.fetchContent).toHaveBeenCalledWith("https://example.com");
-    expect(client.chat).toHaveBeenCalledWith(null, expect.any(String));
+    expect(client.chat).toHaveBeenCalledWith([
+      { role: "user", content: expect.any(String) },
+    ]);
   });
 
   it(// biome-ignore lint/security/noSecrets: test description, not a secret
   "全URL取得失敗時はerrを返す", async () => {
-    const client = createMockCodexClient("response");
+    const client = createMockOpenAIClient("response");
     const fetcher = createMockWebFetcher(new Map());
     const service = new SummaryService(client, fetcher);
 
@@ -81,10 +82,10 @@ describe("SummaryService", () => {
   });
 
   it(// biome-ignore lint/security/noSecrets: test description, not a secret
-  "Codexエラー時はerrを返す", async () => {
+  "OpenAIエラー時はerrを返す", async () => {
     const client = {
       chat: vi.fn().mockRejectedValue(new Error("API error")),
-    } as unknown as CodexClient;
+    } as unknown as OpenAIClient;
     const fetcher = createMockWebFetcher(
       new Map([["https://example.com", "text"]]),
     );

--- a/src/ai/services/summary.service.ts
+++ b/src/ai/services/summary.service.ts
@@ -3,7 +3,7 @@ import { ExternalServiceError } from "@/shared/types/errors";
 import { err, ok, type Result } from "@/shared/types/result";
 import { formatForDiscord } from "@/shared/utils/format";
 import { getLogger } from "@/shared/utils/logger";
-import type { CodexClient } from "../client/codex.client";
+import type { OpenAIClient } from "../client/openai.client";
 import {
   buildSummaryPrompt,
   type FetchedContent,
@@ -11,7 +11,7 @@ import {
 
 export class SummaryService {
   constructor(
-    private client: CodexClient,
+    private client: OpenAIClient,
     private webFetcher: WebFetcherClient,
   ) {}
 
@@ -38,12 +38,14 @@ export class SummaryService {
     const prompt = buildSummaryPrompt(contents);
 
     try {
-      const result = await this.client.chat(null, prompt);
+      const result = await this.client.chat([
+        { role: "user", content: prompt },
+      ]);
       return ok(formatForDiscord(result.response));
     } catch (e) {
       return err(
         new ExternalServiceError(
-          "Codex",
+          "OpenAI",
           e instanceof Error ? e.message : String(e),
         ),
       );

--- a/src/app/bootstrap.test.ts
+++ b/src/app/bootstrap.test.ts
@@ -73,9 +73,9 @@ function setupMocks(
   vi.doMock("@chat-adapter/discord", () => ({
     createDiscordAdapter: vi.fn().mockReturnValue({}),
   }));
-  vi.doMock("@/ai/client/codex.client", () => ({
+  vi.doMock("@/ai/client/openai.client", () => ({
     // biome-ignore lint/complexity/useArrowFunction: constructor mock requires function expression
-    CodexClient: vi.fn().mockImplementation(function () {
+    OpenAIClient: vi.fn().mockImplementation(function () {
       return {};
     }),
   }));
@@ -298,12 +298,12 @@ describe("bootstrap API key selection", () => {
       { CODEX_API_KEY: "codex-key", OPENAI_API_KEY: "openai-key" },
     );
 
-    const { CodexClient } = await import("@/ai/client/codex.client");
+    const { OpenAIClient } = await import("@/ai/client/openai.client");
     const { bootstrap } = await import("@/app/bootstrap");
 
     bootstrap();
 
-    expect(CodexClient).toHaveBeenCalledWith(
+    expect(OpenAIClient).toHaveBeenCalledWith(
       "codex-key",
       expect.objectContaining({ baseUrl: undefined, model: undefined }),
     );
@@ -319,19 +319,19 @@ describe("bootstrap API key selection", () => {
       { CODEX_API_KEY: undefined, OPENAI_API_KEY: "openai-key" },
     );
 
-    const { CodexClient } = await import("@/ai/client/codex.client");
+    const { OpenAIClient } = await import("@/ai/client/openai.client");
     const { bootstrap } = await import("@/app/bootstrap");
 
     bootstrap();
 
-    expect(CodexClient).toHaveBeenCalledWith(
+    expect(OpenAIClient).toHaveBeenCalledWith(
       "openai-key",
       expect.objectContaining({ baseUrl: undefined, model: undefined }),
     );
   });
 });
 
-describe("bootstrap CodexClient options", () => {
+describe("bootstrap OpenAIClient options", () => {
   beforeEach(() => {
     vi.resetModules();
     vi.restoreAllMocks();
@@ -339,7 +339,7 @@ describe("bootstrap CodexClient options", () => {
     mockCreateApp.mockReturnValue({ fetch: vi.fn() });
   });
 
-  it("passes CODEX_BASE_URL and CODEX_MODEL to CodexClient", async () => {
+  it("passes CODEX_BASE_URL and CODEX_MODEL to OpenAIClient", async () => {
     setupMocks(
       {
         bot: { defaultModel: "codex-mini", maxTokens: 4096, timeoutMs: 30000 },
@@ -352,12 +352,12 @@ describe("bootstrap CodexClient options", () => {
       },
     );
 
-    const { CodexClient } = await import("@/ai/client/codex.client");
+    const { OpenAIClient } = await import("@/ai/client/openai.client");
     const { bootstrap } = await import("@/app/bootstrap");
 
     bootstrap();
 
-    expect(CodexClient).toHaveBeenCalledWith(
+    expect(OpenAIClient).toHaveBeenCalledWith(
       "test-key",
       expect.objectContaining({
         baseUrl: "https://custom.api",

--- a/src/app/bootstrap.ts
+++ b/src/app/bootstrap.ts
@@ -1,5 +1,5 @@
 import { createDiscordAdapter } from "@chat-adapter/discord";
-import { CodexClient } from "@/ai/client/codex.client";
+import { OpenAIClient } from "@/ai/client/openai.client";
 import { AIService } from "@/ai/services/ai.service";
 import { SummaryService } from "@/ai/services/summary.service";
 import { loadConfig } from "@/app/config/bot.config";
@@ -20,13 +20,13 @@ import { createLogger, getLogger } from "@/shared/utils/logger";
 function createAIService(): {
   aiService: AIService;
   redis: RedisClient;
-  codex: CodexClient;
+  openai: OpenAIClient;
 } {
   const codexApiKey = env.CODEX_API_KEY ?? env.OPENAI_API_KEY;
   if (!codexApiKey) {
     throw new Error("CODEX_API_KEY or OPENAI_API_KEY is required");
   }
-  const codex = new CodexClient(codexApiKey, {
+  const openai = new OpenAIClient(codexApiKey, {
     baseUrl: env.CODEX_BASE_URL,
     model: env.CODEX_MODEL,
   });
@@ -35,10 +35,10 @@ function createAIService(): {
   redis.connect().catch((err) => {
     getLogger().warn({ err: String(err) }, "Redis connection failed");
   });
-  return { aiService: new AIService(codex, redis), redis, codex };
+  return { aiService: new AIService(openai, redis), redis, openai };
 }
 
-function createDiscordDeps(aiService: AIService, codex: CodexClient) {
+function createDiscordDeps(aiService: AIService, openai: OpenAIClient) {
   const botToken = env.DISCORD_BOT_TOKEN;
   const applicationId = env.DISCORD_APPLICATION_ID;
   if (!botToken) throw new Error("DISCORD_BOT_TOKEN is required");
@@ -50,7 +50,7 @@ function createDiscordDeps(aiService: AIService, codex: CodexClient) {
   });
   const discordClient = new DiscordClient(adapter, botToken, applicationId);
   const chatCommand = new ChatCommand(aiService, discordClient);
-  const summaryService = new SummaryService(codex, new WebFetcherClient());
+  const summaryService = new SummaryService(openai, new WebFetcherClient());
   const summaryCommand = new SummaryCommand(summaryService, discordClient);
   const commands = [new PingCommand(), chatCommand, summaryCommand];
   const messageHandler = new MessageHandler(
@@ -88,14 +88,14 @@ export function bootstrap() {
   const log = getLogger();
   log.debug({ config }, "Config loaded");
 
-  const { aiService, redis, codex } = createAIService();
+  const { aiService, redis, openai } = createAIService();
   const {
     botToken,
     applicationId,
     interactionHandler,
     messageHandler,
     discordClient,
-  } = createDiscordDeps(aiService, codex);
+  } = createDiscordDeps(aiService, openai);
 
   const app = createApp({
     interactionHandler,

--- a/src/app/config/config.yaml
+++ b/src/app/config/config.yaml
@@ -2,7 +2,8 @@ bot:
   defaultModel: "codex-mini"
   maxTokens: 4096
   timeoutMs: 30000
-  allowedUsers: []
+  allowedUsers:
+    - "943827492270137384"
 
 server:
   port: 3000


### PR DESCRIPTION
# チケット

close #46

# 概要

Codex SDKベースのクライアント（`CodexClient`）をOpenAI SDKベースのクライアント（`OpenAIClient`）に移行しました。これにより、スレッドベースの会話管理からメッセージ配列ベースの会話管理へと変更しています。

### 主な変更点

- **OpenAIパッケージの追加**: `openai` (^6.35.0) を依存関係に追加
- **OpenAIClientの新規作成**: `openai` SDKを使用する新しいクライアントを実装
- **AIServiceの移行**: スレッドIDベースからメッセージ履歴（JSON）ベースの会話管理に変更
- **SummaryServiceの移行**: `CodexClient` → `OpenAIClient` に置き換え
- **bootstrapの移行**: DI設定を `CodexClient` → `OpenAIClient` に更新
- **config.yaml**: `allowedUsers` にユーザーIDを追加

# その他

resolves #46